### PR TITLE
HDDS-11039. Release initial version of the Helm chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_GENERATE_RELEASE_NOTES: true
+          CR_SKIP_EXISTING: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          persist-credentials: false
+          submodules: recursive
 
       - name: Configure Git
         run: |
@@ -22,7 +24,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: ./.github/actions/chart-releaser-action
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_GENERATE_RELEASE_NOTES: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule ".github/actions/kind-action"]
 	path = .github/actions/kind-action
 	url = https://github.com/helm/kind-action
+[submodule ".github/actions/chart-releaser-action"]
+	path = .github/actions/chart-releaser-action
+	url = https://github.com/helm/chart-releaser-action

--- a/README.md
+++ b/README.md
@@ -17,4 +17,30 @@
 
 # Helm charts for Apache Ozone
 
-This repository will provide Helm charts for installing Apache Ozone on Kubernetes.
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+This repository provides Helm charts for installing Apache Ozone on Kubernetes.
+
+## Helm charts repository
+Use the following command to add the repository to Helm client configuration:
+```shell
+helm repo add ozone https://apache.github.io/ozone-helm-charts/
+```
+List the latest stable versions of available Helm charts with the commands:
+```shell
+helm repo update ozone
+helm search repo ozone
+```
+
+## Contributing
+
+All contributions are welcome.
+Please open a [Jira](https://issues.apache.org/jira/projects/HDDS/issues) issue and create a pull request.
+
+For more information, please check the [Contribution guideline](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
+
+## License
+
+The Apache Ozone project is licensed under the Apache 2.0 License.
+
+See the [LICENSE](./LICENSE) file for details.

--- a/charts/ozone/README.md
+++ b/charts/ozone/README.md
@@ -27,7 +27,7 @@ This chart bootstraps an [Apache Ozone](https://ozone.apache.org) deployment on 
 
 ## Requirements
 
-- Kubernetes cluster 1.27+
+- Kubernetes cluster 1.28+
 - Helm 3
 
 ## Helm charts repository

--- a/charts/ozone/README.md
+++ b/charts/ozone/README.md
@@ -47,6 +47,12 @@ helm install ozone ozone/ozone
 helm uninstall ozone
 ```
 
+## Configuration
+Refer default `values.yaml` file of the chart for all the possible configuration properties:
+```shell
+helm show values ozone/ozone
+```
+
 ## Documentation
 
 Documentation lives on the Apache Ozone [website](https://ozone.apache.org/docs/).

--- a/charts/ozone/README.md
+++ b/charts/ozone/README.md
@@ -27,7 +27,7 @@ This chart bootstraps an [Apache Ozone](https://ozone.apache.org) deployment on 
 
 ## Requirements
 
-- Kubernetes cluster 1.28+
+- Kubernetes cluster 1.29+
 - Helm 3
 
 ## Helm charts repository

--- a/charts/ozone/README.md
+++ b/charts/ozone/README.md
@@ -23,12 +23,29 @@
 
 ## Introduction
 
-This chart bootstraps an [Ozone](https://ozone.apache.org) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+This chart bootstraps an [Apache Ozone](https://ozone.apache.org) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
 ## Requirements
 
 - Kubernetes cluster 1.27+
-- Helm 3.0+
+- Helm 3
+
+## Helm charts repository
+Use the following command to add the repository to Helm client configuration:
+```shell
+helm repo add ozone https://apache.github.io/ozone-helm-charts/
+```
+
+## Installing the chart
+Install the chart with `ozone` release name:
+```shell
+helm install ozone ozone/ozone
+```
+
+## Uninstalling the chart
+```shell
+helm uninstall ozone
+```
 
 ## Documentation
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds basic workflow to release Helm charts.

The release happens each time the chart version is bumped in `Chart.yaml` in the `main` branch.
The workflow turns current GitHub project into a self-hosted Helm chart repo and requires the following:
 - Branch `gh-pages` (ideally created from the initial commit) to store the published charts.
 - Enabled GitHub Pages with source branch equal to `gh-pages` (go to Settings/Pages and change the Source Branch).

**Caution! The workflow will release the initial version of the chart as soon as it's merged!**

Links for more details:
 - Helm docs - https://helm.sh/docs/howto/chart_releaser_action/#github-actions-workflow
 - chart-releaser Action - https://github.com/helm/chart-releaser-action

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11039

## How was this patch tested?

Tested in the repository fork:
 - Action https://github.com/dnskr/ozone-helm-charts/actions/runs/9839040223/job/27160243103
 - Release https://github.com/dnskr/ozone-helm-charts/releases/tag/ozone-0.1.0
 - Helm repo index https://dnskr.github.io/ozone-helm-charts/index.yaml