### PR TITLE
HDDS-11118. Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## What changes were proposed in this pull request?
+Provide a one-liner summary of the changes in the PR **Title** field above.
+It should be in the form of `HDDS-1234. Short summary of the change`.
+
+Please describe your PR in detail:
+* What changes are proposed in the PR? and Why? It would be better if it is written from third person's
+  perspective not just for the reviewer.
+* Provide as much context and rationale for the pull request as possible. It could be copy-paste from
+  the Jira's description if the jira is well defined.
+* If it is complex code, describe the approach used to solve the issue. If possible attach design doc,
+  issue investigation, github discussion, etc.
+
+Examples of well-written pull requests:
+* [#3980](https://github.com/apache/ozone/pull/3980)
+* [#5265](https://github.com/apache/ozone/pull/5265)
+* [#4701](https://github.com/apache/ozone/pull/4701)
+* [#5283](https://github.com/apache/ozone/pull/5283)
+* [#5300](https://github.com/apache/ozone/pull/5300)
+
+## What is the link to the Apache JIRA
+
+Please create an issue in ASF JIRA before opening a pull request, and you need to set the title of the pull
+request which starts with the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
+
+(Please replace this section with the link to the Apache JIRA)
+
+## How was this patch tested?
+
+(Please explain how this patch was tested. Ex: unit tests, manual tests, workflow run on the fork git repo.)
+(If this patch involves UI changes, please attach a screenshot; otherwise, remove this.)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds pull request template similar to https://github.com/apache/ozone repository.
The template file is a copy of the latest [pull_request_template.md](https://github.com/apache/ozone/blob/d6d33f6c510a05c930f09b0d0e9c663404303a7e/.github/pull_request_template.md).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11118

## How was this patch tested?

Tested in the repository fork.