### PR TITLE
HDDS-11598. Create home page for the Helm repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# Helm charts for Apache Ozone
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+This repository provides Helm charts for installing Apache Ozone on Kubernetes.
+
+## Helm charts repository
+Use the following command to add the repository to Helm client configuration:
+```shell
+helm repo add ozone https://apache.github.io/ozone-helm-charts/
+```
+List the latest stable versions of available Helm charts with the commands:
+```shell
+helm repo update ozone
+helm search repo ozone
+```
+
+## Contributing
+
+All contributions are welcome.
+Please open a [Jira](https://issues.apache.org/jira/projects/HDDS/issues) issue and create a pull request.
+
+For more information, please check the [Contribution guideline](https://github.com/apache/ozone/blob/master/CONTRIBUTING.md).
+
+## License
+
+The Apache Ozone project is licensed under the Apache 2.0 License.
+
+See the [LICENSE](./LICENSE) file for details.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+title: Apache Ozone Helm Charts
+description: The official Helm charts repository for Apache Ozone


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR creates home page for the Helm repository at https://apache.github.io/ozone-helm-charts/ similar to other repositories like [Presto](https://prestodb.github.io/presto-helm-charts/), [Argo](https://argoproj.github.io/argo-helm/), [Minio](https://charts.min.io/) etc.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11598

## How was this patch tested?

Tested in the fork repository: https://dnskr.github.io/ozone-helm-charts/
<img width="673" alt="Screenshot 2024-10-20 at 16 06 38" src="https://github.com/user-attachments/assets/1f4fec2f-dfde-4d6b-8855-35eb228b993e">
