### PR TITLE
HDDS-11618. Enable HA modes for OM and SCM

### DIFF
--- a/charts/ozone/templates/_helpers.tpl
+++ b/charts/ozone/templates/_helpers.tpl
@@ -88,7 +88,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   value: {{ include "ozone.scm.cluster.ids" . }}
 {{- range $i, $val := until ( .Values.scm.replicas | int ) }}
 - name: {{ printf "OZONE-SITE.XML_ozone.scm.address.cluster1.ozone-scm-%d" $i }}
-  value: {{ printf "%s-scm-%d.%s-scm-headless.%s.svc.cluster.local" $.Release.Name $i $.Release.Name $.Values.namespace }}
+  value: {{ printf "%s-scm-%d.%s-scm-headless.%s.svc.cluster.local" $.Release.Name $i $.Release.Name $.Release.Namespace }}
 {{- end }}
 - name: OZONE-SITE.XML_ozone.scm.primordial.node.id
   value: "ozone-scm-0"
@@ -109,7 +109,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   value: {{ include "ozone.om.cluster.ids" . }}
 {{- range $i, $val := until ( .Values.om.replicas | int ) }}
 - name: {{ printf "OZONE-SITE.XML_ozone.om.address.cluster1.ozone-om-%d" $i }}
-  value: {{ printf "%s-om-%d.%s-om-headless.%s.svc.cluster.local" $.Release.Name $i $.Release.Name $.Values.namespace }}
+  value: {{ printf "%s-om-%d.%s-om-headless.%s.svc.cluster.local" $.Release.Name $i $.Release.Name $.Release.Namespace }}
 {{- end }}
 {{- else }}
 - name: OZONE-SITE.XML_ozone.om.address

--- a/charts/ozone/templates/_helpers.tpl
+++ b/charts/ozone/templates/_helpers.tpl
@@ -56,69 +56,161 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- $pods := list }}
   {{- $replicas := .Values.om.replicas | int }}
   {{- range $i := until $replicas }}
-    {{- $pods = append $pods (printf "ozone-om-%d" $i) }}
+    {{- $pods = append $pods (printf "%s-om-%d" $.Release.Name $i) }}
   {{- end }}
   {{- $pods | join "," }}
 {{- end }}
 
-{{/* List of comma separated om ids */}}
+{{/* List of comma separated scm ids */}}
 {{- define "ozone.scm.cluster.ids" -}}
   {{- $pods := list }}
   {{- $replicas := .Values.scm.replicas | int }}
   {{- range $i := until $replicas }}
-    {{- $pods = append $pods (printf "ozone-scm-%d" $i) }}
+    {{- $pods = append $pods (printf "%s-scm-%d" $.Release.Name $i) }}
   {{- end }}
   {{- $pods | join "," }}
 {{- end }}
 
-{{/* Common configuration environment variables */}}
-{{- define "ozone.configuration.env" -}}
+{{/* List of decommission om nodes */}}
+{{- define "ozone.om.decommissioned.nodes" -}}
+    {{- $nodes := list }}
+    {{- $statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (printf "%s-om" $.Release.Name) -}}
+    {{- if $statefulset }}
+      {{- $oldCount := $statefulset.spec.replicas | int -}}
+      {{- $newCount := .Values.om.replicas | int }}
+        {{- range $i := until $oldCount }}
+          {{- $minCount := max $newCount 1 -}}
+          {{- if ge $i $minCount }}
+            {{- $nodes = append $nodes (printf "%s-om-%d" $.Release.Name $i) }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- $nodes | join "," }}
+{{- end }}
+
+{{/* List of bootstrap om nodes */}}
+{{- define "ozone.om.bootstrap.nodes" -}}
+    {{- $nodes := list }}
+    {{- $statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (printf "%s-om" $.Release.Name) -}}
+    {{- if $statefulset }}
+      {{- $oldCount := $statefulset.spec.replicas | int -}}
+      {{- $newCount := .Values.om.replicas | int }}
+        {{- range $i := until $newCount }}
+          {{- if ge $i $oldCount }}
+            {{- $nodes = append $nodes (printf "%s-om-%d" $.Release.Name $i) }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- $nodes | join ","}}
+{{- end }}
+
+{{/* List of decommission scm nodes */}}
+{{- define "ozone.scm.decommissioned.nodes" -}}
+    {{- $nodes := list }}
+    {{- $statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (printf "%s-scm" $.Release.Name) -}}
+    {{- if $statefulset }}
+      {{- $oldCount := $statefulset.spec.replicas | int -}}
+      {{- $newCount := .Values.scm.replicas | int }}
+        {{- range $i := until $oldCount }}
+          {{- if ge $i $newCount }}
+            {{- $nodes = append $nodes (printf "%s-scm-%d" $.Release.Name $i) }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- $nodes | join "," -}}
+{{- end }}
+
+{{/* List of decommission data nodes */}}
+{{- define "ozone.data.decommissioned.hosts" -}}
+    {{- $hosts := list }}
+    {{- $statefulset := lookup "apps/v1" "StatefulSet" $.Release.Namespace (printf "%s-datanode" $.Release.Name) -}}
+    {{- if $statefulset }}
+      {{- $oldCount := $statefulset.spec.replicas | int -}}
+      {{- $newCount := .Values.datanode.replicas | int }}
+        {{- range $i := until $oldCount }}
+          {{- if ge $i $newCount }}
+            {{- $hosts = append $hosts (printf "%s-datanode-%d.%s-datanode-headless.%s.svc.cluster.local" $.Release.Name $i $.Release.Name $.Release.Namespace) }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+    {{- $hosts | join "," -}}
+{{- end }}
+
+{{- define "ozone.configuration.env.common" -}}
 - name: OZONE-SITE.XML_hdds.datanode.dir
   value: /data/storage
 - name: OZONE-SITE.XML_ozone.scm.datanode.id.dir
   value: /data
 - name: OZONE-SITE.XML_ozone.metadata.dirs
   value: /data/metadata
-{{- if gt (int .Values.scm.replicas) 1 }}
 - name: OZONE-SITE.XML_ozone.scm.ratis.enable
   value: "true"
 - name: OZONE-SITE.XML_ozone.scm.service.ids
   value: cluster1
 - name: OZONE-SITE.XML_ozone.scm.nodes.cluster1
   value: {{ include "ozone.scm.cluster.ids" . }}
+  {{/*- name: OZONE-SITE.XML_ozone.scm.skip.bootstrap.validation*/}}
+  {{/*  value: {{ quote .Values.scm.skipBootstrapValidation }}*/}}
 {{- range $i, $val := until ( .Values.scm.replicas | int ) }}
-- name: {{ printf "OZONE-SITE.XML_ozone.scm.address.cluster1.ozone-scm-%d" $i }}
+- name: {{ printf "OZONE-SITE.XML_ozone.scm.address.cluster1.%s-scm-%d" $.Release.Name $i }}
   value: {{ printf "%s-scm-%d.%s-scm-headless.%s.svc.cluster.local" $.Release.Name $i $.Release.Name $.Release.Namespace }}
 {{- end }}
 - name: OZONE-SITE.XML_ozone.scm.primordial.node.id
-  value: "ozone-scm-0"
-{{- else }}
-- name: OZONE-SITE.XML_ozone.scm.block.client.address
-  value: {{ include "ozone.scm.pods" . }}
-- name: OZONE-SITE.XML_ozone.scm.client.address
-  value: {{ include "ozone.scm.pods" . }}
-- name: OZONE-SITE.XML_ozone.scm.names
-  value: {{ include "ozone.scm.pods" . }}
-{{- end}}
-{{- if gt (int .Values.om.replicas) 1 }}
+  value: {{ printf "%s-scm-0" $.Release.Name }}
 - name: OZONE-SITE.XML_ozone.om.ratis.enable
   value: "true"
 - name: OZONE-SITE.XML_ozone.om.service.ids
   value: cluster1
-- name: OZONE-SITE.XML_ozone.om.nodes.cluster1
-  value: {{ include "ozone.om.cluster.ids" . }}
-{{- range $i, $val := until ( .Values.om.replicas | int ) }}
-- name: {{ printf "OZONE-SITE.XML_ozone.om.address.cluster1.ozone-om-%d" $i }}
-  value: {{ printf "%s-om-%d.%s-om-headless.%s.svc.cluster.local" $.Release.Name $i $.Release.Name $.Release.Namespace }}
-{{- end }}
-{{- else }}
-- name: OZONE-SITE.XML_ozone.om.address
-  value: {{ include "ozone.om.pods" . }}
-{{- end}}
 - name: OZONE-SITE.XML_hdds.scm.safemode.min.datanode
   value: "3"
 - name: OZONE-SITE.XML_ozone.datanode.pipeline.limit
   value: "1"
 - name: OZONE-SITE.XML_dfs.datanode.use.datanode.hostname
   value: "true"
+{{- end }}
+
+{{/* Common configuration environment variables */}}
+{{- define "ozone.configuration.env" -}}
+{{- $bOmNodes := ternary (splitList "," (include "ozone.om.bootstrap.nodes" .)) (list) (ne "" (include "ozone.om.bootstrap.nodes" .)) }}
+{{- $dOmNodes := ternary (splitList "," (include "ozone.om.decommissioned.nodes" .)) (list) (ne "" (include "ozone.om.decommissioned.nodes" .)) }}
+{{- $activeOmNodes := ternary (splitList "," (include "ozone.om.cluster.ids" .)) (list) (ne "" (include "ozone.om.cluster.ids" .)) }}
+{{ include "ozone.configuration.env.common" . }}
+{{- if gt (len $dOmNodes) 0 }}
+{{- $decomIds := $dOmNodes | join "," }}
+- name: OZONE-SITE.XML_ozone.om.decommissioned.nodes.cluster1
+  value: {{ $decomIds }}
+{{- else}}
+- name: OZONE-SITE.XML_ozone.om.decommissioned.nodes.cluster1
+  value: ""
+{{- end }}
+- name: OZONE-SITE.XML_ozone.om.nodes.cluster1
+  value: {{ $activeOmNodes | join "," }}
+{{- range $tempId := $activeOmNodes }}
+- name: {{ printf "OZONE-SITE.XML_ozone.om.address.cluster1.%s" $tempId }}
+  value: {{ printf "%s.%s-om-headless.%s.svc.cluster.local" $tempId $.Release.Name $.Release.Namespace }}
+{{- end }}
+{{- range $tempId := $dOmNodes }}
+- name: {{ printf "OZONE-SITE.XML_ozone.om.address.cluster1.%s" $tempId }}
+  value: {{ printf "%s-helm-manager-decommission-%s-svc.%s.svc.cluster.local" $.Release.Name $tempId $.Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/* Common configuration environment variables for pre hook */}}
+{{- define "ozone.configuration.env.prehook" -}}
+{{- $bOmNodes := ternary (splitList "," (include "ozone.om.bootstrap.nodes" .)) (list) (ne "" (include "ozone.om.bootstrap.nodes" .)) }}
+{{- $dOmNodes := ternary (splitList "," (include "ozone.om.decommissioned.nodes" .)) (list) (ne "" (include "ozone.om.decommissioned.nodes" .)) }}
+{{- $activeOmNodes := ternary (splitList "," (include "ozone.om.cluster.ids" .)) (list) (ne "" (include "ozone.om.cluster.ids" .)) }}
+{{- $allOmNodes := concat $activeOmNodes $dOmNodes }}
+{{ include "ozone.configuration.env.common" . }}
+- name: OZONE-SITE.XML_ozone.om.decommissioned.nodes.cluster1
+  value: ""
+{{- range $tempId := $allOmNodes }}
+- name: {{ printf "OZONE-SITE.XML_ozone.om.address.cluster1.%s" $tempId }}
+  value: {{ printf "%s.%s-om-headless.%s.svc.cluster.local" $tempId $.Release.Name $.Release.Namespace }}
+{{- end }}
+{{ $allOmNodes = append $allOmNodes "om-leader-transfer"}}
+- name: OZONE-SITE.XML_ozone.om.nodes.cluster1
+  value: {{ $allOmNodes | join "," }}
+- name: "OZONE-SITE.XML_ozone.om.address.cluster1.om-leader-transfer"
+  value: localhost
 {{- end }}

--- a/charts/ozone/templates/datanode/datanode-service-headless.yaml
+++ b/charts/ozone/templates/datanode/datanode-service-headless.yaml
@@ -28,6 +28,10 @@ spec:
   ports:
     - name: ui
       port: {{ .Values.datanode.service.port }}
+    - name: ratis-ipc
+      port: 9858
+    - name: ipc
+      port: 9859
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: datanode

--- a/charts/ozone/templates/datanode/datanode-statefulset.yaml
+++ b/charts/ozone/templates/datanode/datanode-statefulset.yaml
@@ -65,6 +65,10 @@ spec:
           ports:
             - name: ui
               containerPort: {{ .Values.datanode.service.port }}
+            - name: ratis-ipc
+              containerPort: 9858
+            - name: ipc
+              containerPort: 9859
           livenessProbe:
             httpGet:
               path: /

--- a/charts/ozone/templates/helm/om-manager.yaml
+++ b/charts/ozone/templates/helm/om-manager.yaml
@@ -1,0 +1,239 @@
+{{- if or .Values.om.persistence.enabled }}
+{{- $dnodes := ternary (splitList "," (include "ozone.om.decommissioned.nodes" .)) (list) (ne "" (include "ozone.om.decommissioned.nodes" .)) }}
+{{- $env := concat .Values.env .Values.helm.env }}
+{{- $envFrom := concat .Values.envFrom .Values.helm.envFrom }}
+{{- $nodeSelector := or .Values.helm.nodeSelector .Values.nodeSelector }}
+{{- $affinity := or .Values.helm.affinity .Values.affinity }}
+{{- $tolerations := or .Values.helm.tolerations .Values.tolerations }}
+{{- $securityContext := or .Values.helm.securityContext .Values.securityContext }}
+{{- if and (gt (len $dnodes) 0) ( .Values.om.persistence.enabled) }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-helm-manager-leader-transfer" $.Release.Name }}
+  labels:
+    {{- include "ozone.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: helm-manager
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  backoffLimit: {{ $.Values.helm.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "ozone.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: helm-manager
+    spec:
+      containers:
+        - name: om-leader-transfer
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          {{- with $.Values.om.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          args:
+            - sh
+            - -c
+            - |
+              set -e
+              exec ozone admin om transfer -id=cluster1 -n={{ $.Release.Name }}-om-0
+          env:
+            {{- include "ozone.configuration.env.prehook" $ | nindent 12 }}
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: data-ratis-ipc
+              containerPort: 9858
+            - name: data-ipc
+              containerPort: 9859
+            - name: scm-rpc-client
+              containerPort: 9860
+            - name: scm-block-cl
+              containerPort: 9863
+            - name: scm-rpc-data
+              containerPort: 9861
+            - name: scm-ratis
+              containerPort: 9894
+            - name: scm-grpc
+              containerPort: 9895
+            - name: om-rpc
+              containerPort: 9862
+            - name: om-ratis
+              containerPort: 9872
+          volumeMounts:
+            - name: config
+              mountPath: {{ $.Values.configuration.dir }}
+            - name: om-data
+              mountPath: {{ $.Values.om.persistence.path }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: om-data
+          emptyDir: { }
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ $.Release.Name }}-ozone
+              {{- with $.Values.configuration.filesFrom }}
+                {{- tpl (toYaml .) $ | nindent 14 }}
+              {{- end }}
+      restartPolicy: Never
+
+{{- range $dnode := $dnodes }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ printf "%s-helm-manager-decommission-%s" $.Release.Name $dnode }}
+  labels:
+    {{- include "ozone.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: helm-manager
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  backoffLimit: {{ $.Values.helm.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        {{- include "ozone.selectorLabels" $ | nindent 8 }}
+        app.kubernetes.io/component: helm-manager
+    spec:
+      containers:
+        - name: om-decommission
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          {{- with $.Values.om.command }}
+          command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          args:
+            - sh
+            - -c
+            - |
+              set -e
+              decommission_finalizer() {
+                  echo "Init decommission finalizer process..."
+                  while true; do
+                    IFS= read -r line;
+                    echo "$line"
+                    if echo "$line" | grep -q "Successfully decommissioned OM {{ $dnode }}"; then
+                      echo "{{ $dnode }} was successfully decommissioned!"
+                      if [ -d /old{{ $.Values.om.persistence.path }} ]; then
+                        echo "Delete old data on pvc to enable rescheduling without manual PVC deletion!"
+                        rm -rf  /old{{ $.Values.om.persistence.path }}/*
+                        echo "Data deleted!"
+                      fi
+                      break;
+                    fi
+                  done
+                  echo "Decommission finalizer process finished!"
+                  exit 0
+              }
+              exec ozone admin om decommission -id=cluster1 -nodeid={{ $dnode }} -hostname={{ printf "%s-helm-manager-decommission-%s-svc.%s.svc.cluster.local" $.Release.Name $dnode $.Release.Namespace }} | decommission_finalizer
+          env:
+            {{- include "ozone.configuration.env" $ | nindent 12 }}
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: data-ratis-ipc
+              containerPort: 9858
+            - name: data-ipc
+              containerPort: 9859
+            - name: scm-rpc-client
+              containerPort: 9860
+            - name: scm-block-cl
+              containerPort: 9863
+            - name: scm-rpc-data
+              containerPort: 9861
+            - name: scm-ratis
+              containerPort: 9894
+            - name: scm-grpc
+              containerPort: 9895
+            - name: om-rpc
+              containerPort: 9862
+            - name: om-ratis
+              containerPort: 9872
+          volumeMounts:
+            - name: config
+              mountPath: {{ $.Values.configuration.dir }}
+            - name: om-data
+              mountPath: {{ $.Values.om.persistence.path }}
+            - name: om-data-old
+              mountPath: /old{{ $.Values.om.persistence.path }}
+      {{- with $nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $securityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: om-data-old
+          persistentVolumeClaim:
+            claimName: {{ $.Release.Name}}-om-{{ $dnode }}
+        - name: om-data
+          emptyDir: { }
+        - name: config
+          projected:
+            sources:
+              - configMap:
+                  name: {{ $.Release.Name }}-ozone
+              {{- with $.Values.configuration.filesFrom }}
+                {{- tpl (toYaml .) $ | nindent 14 }}
+              {{- end }}
+      restartPolicy: Never
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ printf "%s-helm-manager-decommission-%s-svc" $.Release.Name $dnode }}
+  labels:
+    {{- include "ozone.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: helm-manager
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": hook-succeeded, hook-failed
+spec:
+  selector:
+    job-name: {{ printf "%s-helm-manager-decommission-%s" $.Release.Name $dnode }}
+  ports:
+    - name: rpc
+      port: 9862
+      targetPort: 9862
+    - name: ratis
+      port: 9872
+      targetPort: 9872
+  type: ClusterIP
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ozone/templates/om/om-service-headless.yaml
+++ b/charts/ozone/templates/om/om-service-headless.yaml
@@ -28,6 +28,10 @@ spec:
   ports:
     - name: ui
       port: {{ .Values.om.service.port }}
+    {{- if gt (int .Values.om.replicas) 1 }}
+    - name: ratis
+      port: {{ .Values.om.service.ratisPort }}
+    {{- end }}
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: om

--- a/charts/ozone/templates/om/om-service-headless.yaml
+++ b/charts/ozone/templates/om/om-service-headless.yaml
@@ -28,10 +28,8 @@ spec:
   ports:
     - name: ui
       port: {{ .Values.om.service.port }}
-    {{- if gt (int .Values.om.replicas) 1 }}
     - name: ratis
       port: 9872
-    {{- end }}
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: om

--- a/charts/ozone/templates/om/om-service-headless.yaml
+++ b/charts/ozone/templates/om/om-service-headless.yaml
@@ -30,7 +30,7 @@ spec:
       port: {{ .Values.om.service.port }}
     {{- if gt (int .Values.om.replicas) 1 }}
     - name: ratis
-      port: {{ .Values.om.service.ratisPort }}
+      port: 9872
     {{- end }}
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -31,6 +31,7 @@ metadata:
     app.kubernetes.io/component: om
 spec:
   replicas: {{ .Values.om.replicas }}
+  podManagementPolicy: Parallel
   serviceName: {{ .Release.Name }}-om-headless
   selector:
     matchLabels:

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -72,6 +72,10 @@ spec:
               containerPort: 9862
             - name: ui
               containerPort: {{ .Values.om.service.port }}
+            {{- if gt (int .Values.om.replicas) 1 }}
+            - name: ratis
+              containerPort: 9872
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -22,6 +22,8 @@
 {{- $affinity := or .Values.om.affinity .Values.affinity }}
 {{- $tolerations := or .Values.om.tolerations .Values.tolerations }}
 {{- $securityContext := or .Values.om.securityContext .Values.securityContext }}
+{{- $bnodes := ternary (splitList "," (include "ozone.om.bootstrap.nodes" .)) (list) (ne "" (include "ozone.om.bootstrap.nodes" .)) }}
+{{- $activeNodes := ternary (splitList "," (include "ozone.om.cluster.ids" .)) (list) (ne "" (include "ozone.om.cluster.ids" .)) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -31,7 +33,6 @@ metadata:
     app.kubernetes.io/component: om
 spec:
   replicas: {{ .Values.om.replicas }}
-  podManagementPolicy: Parallel
   serviceName: {{ .Release.Name }}-om-headless
   selector:
     matchLabels:
@@ -40,7 +41,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/ozone-configmap.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/ozone-configmap.yaml") . | cat (include "ozone.configuration.env" .) | sha256sum }}
       labels:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: om
@@ -52,9 +53,66 @@ spec:
           {{- with .Values.om.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- with .Values.om.args }}
-          args: {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
+          args:
+            - sh
+            - -c
+            - |
+              set -e
+              HELM_MANAGER_PATH="{{ .Values.om.persistence.path }}{{ .Values.helm.persistence.path }}"
+              HELM_MANAGER_BOOTSTRAPPED_FILE="$HELM_MANAGER_PATH/bootstrapped"
+              {{- $flattenedArgs := join " " $.Values.om.args }}
+              {{- if and (.Values.om.persistence.enabled) (gt (len $bnodes) 0) }}
+                joinArr() {
+                  local IFS=","
+                  echo "$*"
+                }
+                bootstrap_finalizer() {
+                  echo "Init bootrap finalizer process..."
+                  while true; do
+                    IFS= read -r line;
+                    echo "$line"
+                      if echo "$line" | grep -q "Successfully bootstrapped OM $HOSTNAME and joined the Ratis group"; then
+                      echo "$HOSTNAME was successfully bootstrapped!"
+                      mkdir -p "$HELM_MANAGER_PATH"
+                      touch "$HELM_MANAGER_BOOTSTRAPPED_FILE"
+                      break;
+                    fi
+                  done
+                  echo "Bootstrap finalizer process finished!"
+                  exit 0
+                }
+                bootstrapHosts="{{ join "," $bnodes }}"
+                echo "Need to handle bootstrap for nodes $bootstrapHosts"
+                IFS=',' read -r -a hostArray <<< "$bootstrapHosts"
+                doBootstrap=false
+                nodesConfigOverwriteList=()
+                for host in "${hostArray[@]}"; do
+                  if [[ "$host" == "$HOSTNAME" ]]; then
+                    doBootstrap=true
+                    activeNodesConfig="{{ join "," $activeNodes }}"
+                    IFS=',' read -r -a overwriteArray <<< "$activeNodesConfig"
+                    for overwriteHost in "${overwriteArray[@]}"; do
+                      nodesConfigOverwriteList+=("$overwriteHost")
+                      if [[ "$overwriteHost" == "$HOSTNAME" ]]; then
+                        break;
+                      fi
+                    done
+                    break
+                  fi
+                done
+                if [ "$doBootstrap" = true ] && [ ! -f "$HELM_MANAGER_BOOTSTRAPPED_FILE" ]; then
+                  echo "$HOSTNAME must be started with bootstrap arg!"
+                  overwriteCmd="$(joinArr "${nodesConfigOverwriteList[@]}")"
+                  echo "Bootstrapping node config for this node: $overwriteCmd"
+                  exec {{ printf "%s --set ozone.om.nodes.cluster1=" $flattenedArgs }}"$overwriteCmd" --bootstrap | bootstrap_finalizer
+                else
+                  echo "$HOSTNAME must not be started with bootstrap arg!"
+                  exec {{ join " " $.Values.om.args }}
+                fi
+              {{- else }}
+                echo "No bootstrap handling needed!"
+                exec {{ join " " $.Values.om.args }}
+              {{- end }}
           env:
             {{- include "ozone.configuration.env" . | nindent 12 }}
             - name: WAITFOR
@@ -72,10 +130,8 @@ spec:
               containerPort: 9862
             - name: ui
               containerPort: {{ .Values.om.service.port }}
-            {{- if gt (int .Values.om.replicas) 1 }}
             - name: ratis
               containerPort: 9872
-            {{- end }}
           livenessProbe:
             httpGet:
               path: /
@@ -109,7 +165,7 @@ spec:
               {{- end }}
         {{- if not .Values.om.persistence.enabled }}
         - name: {{ .Release.Name }}-om
-          emptyDir: {}
+          emptyDir: { }
         {{- end }}
   {{- if .Values.om.persistence.enabled }}
   volumeClaimTemplates:

--- a/charts/ozone/templates/ozone-configmap.yaml
+++ b/charts/ozone/templates/ozone-configmap.yaml
@@ -21,5 +21,9 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-ozone
   labels: {{- include "ozone.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-upgrade, post-install
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/resource-policy": keep
 data:
   {{- tpl (toYaml .Values.configuration.files) $ | nindent 4 }}

--- a/charts/ozone/templates/scm/scm-service-headless.yaml
+++ b/charts/ozone/templates/scm/scm-service-headless.yaml
@@ -28,6 +28,10 @@ spec:
   ports:
     - name: ui
       port: {{ .Values.scm.service.port }}
+    {{- if gt (int .Values.scm.replicas) 1 }}
+    - name: ratis
+      port: {{ .Values.om.service.ratisPort }}
+    {{- end }}
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: scm

--- a/charts/ozone/templates/scm/scm-service-headless.yaml
+++ b/charts/ozone/templates/scm/scm-service-headless.yaml
@@ -28,9 +28,17 @@ spec:
   ports:
     - name: ui
       port: {{ .Values.scm.service.port }}
+    - name: rpc-datanode
+      port: 9861
+    - name: block-client
+      port: 9863
+    - name: rpc-client
+      port: 9860
     {{- if gt (int .Values.scm.replicas) 1 }}
     - name: ratis
-      port: {{ .Values.om.service.ratisPort }}
+      port: 9894
+    - name: grpc
+      port: 9895
     {{- end }}
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -31,6 +31,7 @@ metadata:
     app.kubernetes.io/component: scm
 spec:
   replicas: {{ .Values.scm.replicas }}
+  podManagementPolicy: Parallel
   serviceName: {{ .Release.Name }}-scm-headless
   selector:
     matchLabels:
@@ -61,6 +62,24 @@ spec:
               mountPath: {{ .Values.configuration.dir }}
             - name: {{ .Release.Name }}-scm
               mountPath: {{ .Values.scm.persistence.path }}
+        {{- if gt (int .Values.scm.replicas) 1 }}
+        - name: bootstrap
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          args: ["ozone", "scm", "--bootstrap"]
+          env:
+            {{- include "ozone.configuration.env" . | nindent 12 }}
+            {{- with $env }}
+              {{- tpl (toYaml .) $ | nindent 12 }}
+            {{- end }}
+          {{- with $envFrom }}
+          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: {{ .Values.configuration.dir }}
+            - name: {{ .Release.Name }}-scm
+              mountPath: {{ .Values.scm.persistence.path }}
+        {{- end }}
       containers:
         - name: scm
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -101,10 +101,18 @@ spec:
           ports:
             - name: rpc-client
               containerPort: 9860
+            - name: block-client
+              containerPort: 9863
             - name: rpc-datanode
               containerPort: 9861
             - name: ui
               containerPort: {{ .Values.scm.service.port }}
+            {{- if gt (int .Values.scm.replicas) 1 }}
+            - name: ratis
+              containerPort: 9894
+            - name: grpc
+              containerPort: 9895
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -19,6 +19,8 @@ image:
   pullPolicy: IfNotPresent
   tag: ~
 
+namespace: default
+
 imagePullSecrets: []
 
 # Common environment variables (templated)
@@ -123,6 +125,7 @@ om:
     type: ClusterIP
     port: 9874
     nodePort: ~
+    ratisPort: 9894
   # Ozone Manager persistence
   persistence:
     # Enable persistence
@@ -201,6 +204,7 @@ scm:
     type: ClusterIP
     port: 9876
     nodePort: ~
+    ratisPort: 9894
   # Storage Container Manager persistence
   persistence:
     # Enable persistence

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -214,3 +214,35 @@ scm:
     size: 10Gi
     # The name of a specific storage class name to use
     storageClassName: ~
+
+# Helm Manager configuration
+helm:
+  # Additional Helm Manager environment variables (templated)
+  env: []
+  # Additional Helm Manager envFrom items to set up environment variables (templated)
+  envFrom: []
+  # Constrain Helm Manager pods to nodes with specific node labels
+  nodeSelector: {}
+  # Constrain Helm Manager pods to nodes by affinity/anti-affinity rules
+  affinity: {}
+  # Allow to schedule Helm Manager pods on nodes with matching taints
+  tolerations: []
+  # Helm Manager security context (overwrites common security context)
+  securityContext: {}
+  # Decommissioning is handled with a post-upgrade helm hook job.
+  # To avoid endless retries of decommissioning, this limit is set.
+  # This can happen if PVC has been deleted or is not reachable.
+  # This is used for decommissioning OM
+  backoffLimit: 5
+  # Helm Manager persistence (this is enabled automatically if al least one
+  # of datanode, scm or om is enabled)
+  persistence:
+    # Persistence access modes
+    accessModes:
+      - ReadWriteOnce
+    # Path for Helm Manager volume mount
+    path: /metadata/helm
+    # Volume size
+    size: 5Mi
+    # The name of a specific storage class name to use
+    storageClassName: ~

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -237,12 +237,5 @@ helm:
   # Helm Manager persistence (this is enabled automatically if al least one
   # of datanode, scm or om is enabled)
   persistence:
-    # Persistence access modes
-    accessModes:
-      - ReadWriteOnce
     # Path for Helm Manager volume mount
     path: /metadata/helm
-    # Volume size
-    size: 5Mi
-    # The name of a specific storage class name to use
-    storageClassName: ~

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -123,7 +123,6 @@ om:
     type: ClusterIP
     port: 9874
     nodePort: ~
-    ratisPort: 9894
   # Ozone Manager persistence
   persistence:
     # Enable persistence
@@ -202,7 +201,6 @@ scm:
     type: ClusterIP
     port: 9876
     nodePort: ~
-    ratisPort: 9894
   # Storage Container Manager persistence
   persistence:
     # Enable persistence

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -19,8 +19,6 @@ image:
   pullPolicy: IfNotPresent
   tag: ~
 
-namespace: default
-
 imagePullSecrets: []
 
 # Common environment variables (templated)


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDDS-11618. The changes enable HA modes for OM and SCM over replica count.

Please describe your PR in detail:
* What changes are proposed in the PR? and Why? It would be better if it is written from third person's
  perspective not just for the reviewer.

In Kubernetes clusters, redundancy is crucial. However, using more than one instance of OM or SCM results in multiple errors with the current configuration. To address this, the HA configuration described in the official documentation has been integrated into this Helm chart.

* Provide as much context and rationale for the pull request as possible. It could be copy-paste from
  the Jira's description if the jira is well defined.

The main purpose is to enable Ratis over replica counts and to enable bootstrap for SCM by adding a new init container. Additionally, proper cluster configuration has been introduced. When the replica count is set to 1, a standalone configuration is maintained to ensure backwards compatibility.

* If it is complex code, describe the approach used to solve the issue. If possible attach design doc,
  issue investigation, github discussion, etc.

Please refere [OM HA DOC](https://ozone.apache.org/docs/current/feature/om-ha.html) and [SCM HA DOC](https://ozone.apache.org/docs/current/feature/scm-ha.html)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11618

## How was this patch tested?

This patch was tested using the Git workflow and manual cluster tests with a Rancher Kubernetes cluster. It was evaluated both as a standalone and an HA version. Additionally, it was tested in a plain new Kubernetes cluster and as a dependency chart.