### PR TITLE
HDDS-11832. Upgrade default Ozone version in the Helm chart to 1.4.1

### DIFF
--- a/charts/ozone/Chart.yaml
+++ b/charts/ozone/Chart.yaml
@@ -19,7 +19,7 @@ name: ozone
 description: The official Helm chart for Apache Ozone
 type: application
 version: 0.1.1
-appVersion: "1.4.0"
+appVersion: "1.4.1-rocky"
 home: https://ozone.apache.org
 icon: https://ozone.apache.org/ozone-logo.png
 sources:


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR upgrades default Ozone version to the latests 1.4.1 version.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11832

## How was this patch tested?

### Test 1 
Release the chart with default values:
```shell
helm install ozone charts/ozone 
```
Test case: create bucket -> upload file -> download file.

### Test 2
Release the chart with persistence enabled:
```shell
helm install ozone charts/ozone --set datanode.persistence.enabled=true --set om.persistence.enabled=true --set s3g.persistence.enabled=true --set scm.persistence.enabled=true
```
Test case: create bucket -> upload file -> download file -> uninstall the chart -> install the chart again -> download file.