### PR TITLE
HDDS-11841. Add support for additional service labels and annotations

### DIFF
--- a/charts/ozone/templates/datanode/datanode-service.yaml
+++ b/charts/ozone/templates/datanode/datanode-service.yaml
@@ -23,6 +23,12 @@ metadata:
   labels:
     {{- include "ozone.labels" . | nindent 4 }}
     app.kubernetes.io/component: datanode
+    {{- with .Values.datanode.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.datanode.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.datanode.service.type }}
   ports:

--- a/charts/ozone/templates/om/om-service.yaml
+++ b/charts/ozone/templates/om/om-service.yaml
@@ -23,6 +23,12 @@ metadata:
   labels:
     {{- include "ozone.labels" . | nindent 4 }}
     app.kubernetes.io/component: om
+    {{- with .Values.om.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.om.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.om.service.type }}
   ports:

--- a/charts/ozone/templates/s3g/s3g-service.yaml
+++ b/charts/ozone/templates/s3g/s3g-service.yaml
@@ -23,6 +23,12 @@ metadata:
   labels:
     {{- include "ozone.labels" . | nindent 4 }}
     app.kubernetes.io/component: s3g
+    {{- with .Values.s3g.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.s3g.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.s3g.service.type }}
   ports:

--- a/charts/ozone/templates/scm/scm-service.yaml
+++ b/charts/ozone/templates/scm/scm-service.yaml
@@ -23,6 +23,12 @@ metadata:
   labels:
     {{- include "ozone.labels" . | nindent 4 }}
     app.kubernetes.io/component: scm
+    {{- with .Values.scm.service.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.scm.service.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.scm.service.type }}
   ports:

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -84,6 +84,8 @@ datanode:
     type: ClusterIP
     port: 9882
     nodePort: ~
+    labels: {}
+    annotations: {}
   # Datanode persistence
   persistence:
     # Enable persistence
@@ -123,6 +125,8 @@ om:
     type: ClusterIP
     port: 9874
     nodePort: ~
+    labels: {}
+    annotations: {}
   # Ozone Manager persistence
   persistence:
     # Enable persistence
@@ -162,6 +166,8 @@ s3g:
     type: ClusterIP
     port: 9878
     nodePort: ~
+    labels: {}
+    annotations: {}
   # S3 Gateway persistence
   persistence:
     # Enable persistence
@@ -201,6 +207,8 @@ scm:
     type: ClusterIP
     port: 9876
     nodePort: ~
+    labels: {}
+    annotations: {}
   # Storage Container Manager persistence
   persistence:
     # Enable persistence


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds support for additional service labels and annotations which can be added to a Helm chart releases via values.

The change is needed in some scenarios, for example:

- Add prometheus related annotations to scrape metrics
  ```yaml
  apiVersion: v1
  kind: Service
  metadata:
    annotations:
      prometheus.io/port: "9500"
      prometheus.io/scrape: "true"
  ```
- Add additional labels for different environments

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11841

## How was this patch tested?

#### 1. Test that service templates are the same with default values (no extra labels and annotations)
```shell
helm template ozone charts/ozone -s templates/datanode/datanode-service.yaml \
                                                   -s templates/om/om-service.yaml \
                                                   -s templates/s3g/s3g-service.yaml \
                                                   -s templates/scm/scm-service.yam
```
Output
```yaml
---
# Source: ozone/templates/datanode/datanode-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-datanode
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: datanode
spec:
  type: ClusterIP
  ports:
    - name: ui
      port: 9882
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: datanode
---
# Source: ozone/templates/om/om-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-om
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: om
spec:
  type: ClusterIP
  ports:
    - name: ui
      port: 9874
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: om
---
# Source: ozone/templates/s3g/s3g-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-s3g
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: s3g
spec:
  type: ClusterIP
  ports:
    - name: rest
      port: 9878
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: s3g
---
# Source: ozone/templates/scm/scm-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-scm
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: scm
spec:
  type: ClusterIP
  ports:
    - name: ui
      port: 9876
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: scm
```
#### 2. Test that templates are correct with provided additional labels and annotations
```shell
helm template ozone charts/ozone --set datanode.service.labels.test=datanode \
                                                   --set datanode.service.annotations.path=datanode \
                                                   --set om.service.labels.test=om \
                                                   --set om.service.annotations.path=om \
                                                   --set s3g.service.labels.test=s3g \
                                                   --set s3g.service.annotations.path=s3g \
                                                   --set scm.service.labels.test=scm \
                                                   --set scm.service.annotations.path=scm \
                                                   -s templates/datanode/datanode-service.yaml \
                                                   -s templates/om/om-service.yaml \
                                                   -s templates/s3g/s3g-service.yaml \
                                                   -s templates/scm/scm-service.yaml
```
Output
```yaml
---
# Source: ozone/templates/datanode/datanode-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-datanode
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: datanode
    test: datanode
  annotations:
    path: datanode
spec:
  type: ClusterIP
  ports:
    - name: ui
      port: 9882
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: datanode
---
# Source: ozone/templates/om/om-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-om
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: om
    test: om
  annotations:
    path: om
spec:
  type: ClusterIP
  ports:
    - name: ui
      port: 9874
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: om
---
# Source: ozone/templates/s3g/s3g-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-s3g
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: s3g
    test: s3g
  annotations:
    path: s3g
spec:
  type: ClusterIP
  ports:
    - name: rest
      port: 9878
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: s3g
---
# Source: ozone/templates/scm/scm-service.yaml
apiVersion: v1
kind: Service
metadata:
  name: ozone-scm
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: scm
    test: scm
  annotations:
    path: scm
spec:
  type: ClusterIP
  ports:
    - name: ui
      port: 9876
  selector:
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/component: scm
```
