### PR TITLE
HDDS-11918. Add support for resource requests and limits

### DIFF
--- a/charts/ozone/templates/datanode/datanode-statefulset.yaml
+++ b/charts/ozone/templates/datanode/datanode-statefulset.yaml
@@ -70,6 +70,9 @@ spec:
               path: /
               port: ui
             initialDelaySeconds: 30
+          {{- with .Values.datanode.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.configuration.dir }}

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -76,6 +76,9 @@ spec:
               path: /
               port: ui
             initialDelaySeconds: 60
+          {{- with .Values.om.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.configuration.dir }}

--- a/charts/ozone/templates/s3g/s3g-statefulset.yaml
+++ b/charts/ozone/templates/s3g/s3g-statefulset.yaml
@@ -70,6 +70,9 @@ spec:
               path: /
               port: rest
             initialDelaySeconds: 30
+          {{- with .Values.s3g.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.configuration.dir }}

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -91,6 +91,9 @@ spec:
               path: /
               port: ui
             initialDelaySeconds: 30
+          {{- with .Values.scm.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: {{ .Values.configuration.dir }}

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -71,6 +71,8 @@ datanode:
   env: []
   # Additional Datanode envFrom items to set up environment variables (templated)
   envFrom: []
+  # Datanode resource requests and limits
+  resources: {}
   # Constrain Datanode pods to nodes with specific node labels
   nodeSelector: {}
   # Constrain Datanode pods to nodes by affinity/anti-affinity rules
@@ -112,6 +114,8 @@ om:
   env: []
   # Additional Ozone Manager envFrom items to set up environment variables (templated)
   envFrom: []
+  # Ozone Manager resource requests and limits
+  resources: {}
   # Constrain Ozone Manager pods to nodes with specific node labels
   nodeSelector: {}
   # Constrain Ozone Manager pods to nodes by affinity/anti-affinity rules
@@ -153,6 +157,8 @@ s3g:
   env: []
   # Additional S3 Gateway envFrom items to set up environment variables (templated)
   envFrom: []
+  # S3 Gateway resource requests and limits
+  resources: {}
   # Constrain S3 Gateway pods to nodes with specific node labels
   nodeSelector: {}
   # Constrain S3 Gateway pods to nodes by affinity/anti-affinity rules
@@ -194,6 +200,8 @@ scm:
   env: []
   # Additional Storage Container Manager envFrom items to set up environment variables (templated)
   envFrom: []
+  # Storage Container Manager resource requests and limits
+  resources: {}
   # Constrain Storage Container Manager pods to nodes with specific node labels
   nodeSelector: {}
   # Constrain Storage Container Manager pods to nodes by affinity/anti-affinity rules


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds support for resource requests and limits to be set to Datanode, Ozone Manager, S3 Gateway and Storage Container Manager containers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11918

## How was this patch tested?

**1. Test that `StatefulSet` templates don't have `resources` field by default**
```shell
helm template ozone charts/ozone -s templates/datanode/datanode-statefulset.yaml \
                                 -s templates/om/om-statefulset.yaml \
                                 -s templates/s3g/s3g-statefulset.yaml \
                                 -s templates/scm/scm-statefulset.yaml
```

```yaml
---
# Source: ozone/templates/datanode/datanode-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-datanode
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: datanode
spec:
  replicas: 3
  serviceName: ozone-datanode-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: datanode
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: datanode
    spec:
      containers:
        - name: datanode
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - datanode
          env:
            ...
          ports:
            - name: ui
              containerPort: 9882
          livenessProbe:
            httpGet:
              path: /
              port: ui
            initialDelaySeconds: 30
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-datanode
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-datanode
          emptyDir: {}
---
# Source: ozone/templates/om/om-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-om
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: om
spec:
  replicas: 1
  serviceName: ozone-om-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: om
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: om
    spec:
      containers:
        - name: om
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - om
          env:
            ...
          ports:
            - name: rpc
              containerPort: 9862
            - name: ui
              containerPort: 9874
          livenessProbe:
            httpGet:
              path: /
              port: ui
            initialDelaySeconds: 60
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-om
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-om
          emptyDir: {}
---
# Source: ozone/templates/s3g/s3g-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-s3g
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: s3g
spec:
  replicas: 1
  serviceName: ozone-s3g-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: s3g
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: s3g
    spec:
      containers:
        - name: s3g
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - s3g
          env:
            ...
          ports:
            - name: rest
              containerPort: 9878
          livenessProbe:
            httpGet:
              path: /
              port: rest
            initialDelaySeconds: 30
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-s3g
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-s3g
          emptyDir: {}
---
# Source: ozone/templates/scm/scm-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-scm
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: scm
spec:
  replicas: 1
  serviceName: ozone-scm-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: scm
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: scm
    spec:
      initContainers:
        - name: init
          image: "apache/ozone:1.4.1-rocky"
          args: ["ozone", "scm", "--init"]
          env:
            ...
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-scm
              mountPath: /data
      containers:
        - name: scm
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - scm
          env:
            ...
          ports:
            - name: rpc-client
              containerPort: 9860
            - name: rpc-datanode
              containerPort: 9861
            - name: ui
              containerPort: 9876
          livenessProbe:
            httpGet:
              path: /
              port: ui
            initialDelaySeconds: 30
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-scm
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-scm
          emptyDir: {}
```

**2. Test that templates are correct with provided resource values**
```shell
helm template ozone charts/ozone --set datanode.resources.requests.cpu=101m \
                                 --set datanode.resources.limits.cpu=1001m \
                                 --set om.resources.requests.cpu=102m \
                                 --set om.resources.limits.cpu=1002m \
                                 --set s3g.resources.requests.cpu=103m \
                                 --set s3g.resources.limits.cpu=1003m \
                                 --set scm.resources.requests.cpu=104m \
                                 --set scm.resources.limits.cpu=1004m \
                                 -s templates/datanode/datanode-statefulset.yaml \
                                 -s templates/om/om-statefulset.yaml \
                                 -s templates/s3g/s3g-statefulset.yaml \
                                 -s templates/scm/scm-statefulset.yaml
```
```yaml
---
# Source: ozone/templates/datanode/datanode-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-datanode
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: datanode
spec:
  replicas: 3
  serviceName: ozone-datanode-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: datanode
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: datanode
    spec:
      containers:
        - name: datanode
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - datanode
          env:
            ...
          ports:
            - name: ui
              containerPort: 9882
          livenessProbe:
            httpGet:
              path: /
              port: ui
            initialDelaySeconds: 30
          resources:
            limits:
              cpu: 1001m
            requests:
              cpu: 101m
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-datanode
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-datanode
          emptyDir: {}
---
# Source: ozone/templates/om/om-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-om
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: om
spec:
  replicas: 1
  serviceName: ozone-om-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: om
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: om
    spec:
      containers:
        - name: om
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - om
          env:
            ...
          ports:
            - name: rpc
              containerPort: 9862
            - name: ui
              containerPort: 9874
          livenessProbe:
            httpGet:
              path: /
              port: ui
            initialDelaySeconds: 60
          resources:
            limits:
              cpu: 1002m
            requests:
              cpu: 102m
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-om
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-om
          emptyDir: {}
---
# Source: ozone/templates/s3g/s3g-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-s3g
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: s3g
spec:
  replicas: 1
  serviceName: ozone-s3g-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: s3g
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: s3g
    spec:
      containers:
        - name: s3g
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - s3g
          env:
            ...
          ports:
            - name: rest
              containerPort: 9878
          livenessProbe:
            httpGet:
              path: /
              port: rest
            initialDelaySeconds: 30
          resources:
            limits:
              cpu: 1003m
            requests:
              cpu: 103m
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-s3g
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-s3g
          emptyDir: {}
---
# Source: ozone/templates/scm/scm-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-scm
  labels:
    helm.sh/chart: ozone-0.1.1
    app.kubernetes.io/name: ozone
    app.kubernetes.io/instance: ozone
    app.kubernetes.io/version: "1.4.1-rocky"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: scm
spec:
  replicas: 1
  serviceName: ozone-scm-headless
  selector:
    matchLabels:
      app.kubernetes.io/name: ozone
      app.kubernetes.io/instance: ozone
      app.kubernetes.io/component: scm
  template:
    metadata:
      annotations:
        checksum/config: 1b660e279be09a3478618699d32bc5d39aa745dadb24ecab06fe5d37e616839f
      labels:
        app.kubernetes.io/name: ozone
        app.kubernetes.io/instance: ozone
        app.kubernetes.io/component: scm
    spec:
      initContainers:
        - name: init
          image: "apache/ozone:1.4.1-rocky"
          args: ["ozone", "scm", "--init"]
          env:
            ...
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-scm
              mountPath: /data
      containers:
        - name: scm
          image: "apache/ozone:1.4.1-rocky"
          imagePullPolicy: IfNotPresent
          args:
            - ozone
            - scm
          env:
            ...
          ports:
            - name: rpc-client
              containerPort: 9860
            - name: rpc-datanode
              containerPort: 9861
            - name: ui
              containerPort: 9876
          livenessProbe:
            httpGet:
              path: /
              port: ui
            initialDelaySeconds: 30
          resources:
            limits:
              cpu: 1004m
            requests:
              cpu: 104m
          volumeMounts:
            - name: config
              mountPath: /opt/hadoop/etc/hadoop
            - name: ozone-scm
              mountPath: /data
      volumes:
        - name: config
          projected:
            sources:
              - configMap:
                  name: ozone-ozone
        - name: ozone-scm
          emptyDir: {}
```

**3. Test that the chart can be installed with provided resource values**
```shell
helm install ozone charts/ozone --set datanode.resources.requests.cpu=101m \
                                --set datanode.resources.limits.cpu=1001m \
                                --set om.resources.requests.cpu=102m \
                                --set om.resources.limits.cpu=1002m \
                                --set s3g.resources.requests.cpu=103m \
                                --set s3g.resources.limits.cpu=1003m \
                                --set scm.resources.requests.cpu=104m \
                                --set scm.resources.limits.cpu=1004m
```

```shell
kubectl get pod -o custom-columns='NAME:.metadata.name,CPU_REQUESTS:.spec.containers[0].resources.requests.cpu,CPU_LIMITS:.spec.containers[0].resources.limits.cpu'
NAME               CPU_REQUESTS   CPU_LIMITS
ozone-datanode-0   101m           1001m
ozone-datanode-1   101m           1001m
ozone-datanode-2   101m           1001m
ozone-om-0         102m           1002m
ozone-s3g-0        103m           1003m
ozone-scm-0        104m           1004m
```
