### PR TITLE
HDDS-11936. Bump actions/checkout to v4 in the release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR updates `actions/checkout` version from `v3` to `v4` [similar to the test workflow](https://github.com/apache/ozone-helm-charts/blob/1619b1a4cd3075c54a1a94c9e36a2b05c65f74ce/.github/workflows/test.yaml#L13).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-11936

## How was this patch tested?

Successful test workflow (uses `actions/checkout@v4`) runs.