### PR TITLE
HDDS-12466. Set default commit message to PR title

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,6 +25,7 @@ github:
     - container
   enabled_merge_buttons:
     squash:  true
+    squash_commit_message: PR_TITLE
     merge:   false
     rebase:  false
   ghp_branch: gh-pages


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set default commit message to the PR title during merge.  The title can still be edited if needed, but we can avoid picking up single commit's possibly bad message.

https://issues.apache.org/jira/browse/HDDS-12466

## How was this patch tested?

Tested same change in other repo (https://github.com/apache/ozone-docker-testkrb5/pull/13).