### PR TITLE
HDDS-12683. Update Helm Chart to use Ozone 2.0.0

### DIFF
--- a/charts/ozone/Chart.yaml
+++ b/charts/ozone/Chart.yaml
@@ -19,7 +19,7 @@ name: ozone
 description: The official Helm chart for Apache Ozone
 type: application
 version: 0.1.1
-appVersion: "1.4.1-rocky"
+appVersion: "2.0.0"
 home: https://ozone.apache.org
 icon: https://ozone.apache.org/ozone-logo.png
 sources:

--- a/charts/ozone/Chart.yaml
+++ b/charts/ozone/Chart.yaml
@@ -18,7 +18,7 @@ apiVersion: v2
 name: ozone
 description: The official Helm chart for Apache Ozone
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "2.0.0"
 home: https://ozone.apache.org
 icon: https://ozone.apache.org/ozone-logo.png

--- a/charts/ozone/templates/NOTES.txt
+++ b/charts/ozone/templates/NOTES.txt
@@ -43,5 +43,8 @@ Datanode
  {{- end }}
 
 S3 Gateway
- To access S3 Gateway from a local environment, use the following command and specify localhost:{{ .Values.s3g.service.port }} as S3 endpoint
- $ kubectl port-forward svc/{{ .Release.Name }}-s3g {{ .Values.s3g.service.port }}:{{ .Values.s3g.service.port }}
+ To access S3 API from a local environment, use the following command and specify localhost:{{ .Values.s3g.service.rest.port }} as S3 endpoint
+ $ kubectl port-forward svc/{{ .Release.Name }}-s3g-rest {{ .Values.s3g.service.rest.port }}:{{ .Values.s3g.service.rest.port }}
+
+ To access S3 Gateway from a browser, use the following command and visit localhost:{{ .Values.s3g.service.web.port }}
+ $ kubectl port-forward svc/{{ .Release.Name }}-s3g-web {{ .Values.s3g.service.web.port }}:{{ .Values.s3g.service.web.port }}

--- a/charts/ozone/templates/_helpers.tpl
+++ b/charts/ozone/templates/_helpers.tpl
@@ -56,7 +56,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: OZONE-SITE.XML_hdds.datanode.dir
   value: /data/storage
 - name: OZONE-SITE.XML_ozone.scm.datanode.id.dir
-  value: /data
+  value: /data/metadata
 - name: OZONE-SITE.XML_ozone.metadata.dirs
   value: /data/metadata
 - name: OZONE-SITE.XML_ozone.scm.block.client.address

--- a/charts/ozone/templates/s3g/s3g-service-rest.yaml
+++ b/charts/ozone/templates/s3g/s3g-service-rest.yaml
@@ -19,23 +19,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-s3g
+  name: {{ .Release.Name }}-s3g-rest
   labels:
     {{- include "ozone.labels" . | nindent 4 }}
     app.kubernetes.io/component: s3g
-    {{- with .Values.s3g.service.labels }}
+    {{- with .Values.s3g.service.rest.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.s3g.service.annotations }}
+  {{- with .Values.s3g.service.rest.annotations }}
   annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.s3g.service.type }}
+  type: {{ .Values.s3g.service.rest.type }}
   ports:
     - name: rest
-      port: {{ .Values.s3g.service.port }}
-      {{- if and (eq .Values.s3g.service.type "NodePort") (.Values.s3g.service.nodePort) }}
-      nodePort: {{ .Values.s3g.service.nodePort }}
+      port: {{ .Values.s3g.service.rest.port }}
+      {{- if and (eq .Values.s3g.service.rest.type "NodePort") (.Values.s3g.service.rest.nodePort) }}
+      nodePort: {{ .Values.s3g.service.rest.nodePort }}
       {{- end }}
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}

--- a/charts/ozone/templates/s3g/s3g-service-web.yaml
+++ b/charts/ozone/templates/s3g/s3g-service-web.yaml
@@ -19,15 +19,24 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}-s3g-headless
+  name: {{ .Release.Name }}-s3g-web
   labels:
     {{- include "ozone.labels" . | nindent 4 }}
     app.kubernetes.io/component: s3g
+    {{- with .Values.s3g.service.web.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.s3g.service.web.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  clusterIP: None
+  type: {{ .Values.s3g.service.web.type }}
   ports:
-    - name: rest
-      port: {{ .Values.s3g.service.rest.port }}
+    - name: web
+      port: {{ .Values.s3g.service.web.port }}
+      {{- if and (eq .Values.s3g.service.web.type "NodePort") (.Values.s3g.service.web.nodePort) }}
+      nodePort: {{ .Values.s3g.service.web.nodePort }}
+      {{- end }}
   selector:
     {{- include "ozone.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: s3g

--- a/charts/ozone/templates/s3g/s3g-statefulset.yaml
+++ b/charts/ozone/templates/s3g/s3g-statefulset.yaml
@@ -64,11 +64,13 @@ spec:
           {{- end }}
           ports:
             - name: rest
-              containerPort: {{ .Values.s3g.service.port }}
+              containerPort: {{ .Values.s3g.service.rest.port }}
+            - name: web
+              containerPort: {{ .Values.s3g.service.web.port }}
           livenessProbe:
             httpGet:
               path: /
-              port: rest
+              port: web
             initialDelaySeconds: 30
           {{- with .Values.s3g.resources }}
           resources: {{- toYaml . | nindent 12 }}

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -169,11 +169,18 @@ s3g:
   securityContext: {}
   # S3 Gateway service configuration
   service:
-    type: ClusterIP
-    port: 9878
-    nodePort: ~
-    labels: {}
-    annotations: {}
+    rest:
+      type: ClusterIP
+      port: 9878
+      nodePort: ~
+      labels: {}
+      annotations: {}
+    web:
+      type: ClusterIP
+      port: 19878
+      nodePort: ~
+      labels: {}
+      annotations: {}
   # S3 Gateway persistence
   persistence:
     # Enable persistence


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR updates Helm chart to use the latest Ozone 2.0.0 version.

**Note: This PR releases a new 0.2.0 version of the Helm chart when merged!**

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-12683

## How was this patch tested?

Install the chart with default values:
```shell
helm install ozone charts/ozone
```

Check all pods are up and running:
```shell
kubectl get pod
NAME               READY   STATUS    RESTARTS   AGE
ozone-datanode-0   1/1     Running   0          19m
ozone-datanode-1   1/1     Running   0          19m
ozone-datanode-2   1/1     Running   0          19m
ozone-om-0         1/1     Running   0          19m
ozone-s3g-0        1/1     Running   0          19m
ozone-scm-0        1/1     Running   0          19m
```

Access S3 endpoint:
```shell
kubectl port-forward svc/ozone-s3g-rest 9878:9878
```

Access  S3 Gateway from a browser:
```shell
kubectl port-forward svc/ozone-s3g-web 19878:19878
```