### PR TITLE
HDDS-14901. Enable Dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # 'daily' only runs on weekdays
+      interval: "cron"
+      cronjob: "15 9 * * *"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable Dependabot for automated update of GitHub Actions.

https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#github-actions

https://issues.apache.org/jira/browse/HDDS-14901

## How was this patch tested?

CI:
https://github.com/adoroszlai/ozone-helm-charts/actions/runs/23944649569

`dependabot.yml` will be tested after merge (but similar config already used in other Ozone repos).