### PR TITLE
HDDS-14920. Check actions with zizmor

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Release Charts
 
 on:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,8 @@ on:
     types: [opened, synchronize]
   push:
 
+permissions: { }
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Test Charts
 
 on:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,10 +32,12 @@ jobs:
       - name: Find changes (PR)
         if: github.event_name == 'pull_request'
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.base_ref }})
+          changed=$(ct list-changed --target-branch "$base_ref")
           if [[ -n "$changed" ]]; then
-            echo "test_scope=--target-branch ${{ github.base_ref }}" >> "$GITHUB_ENV"
+            echo "test_scope=--target-branch '$base_ref'" >> "$GITHUB_ENV"
           fi
+        env:
+          base_ref: ${{ github.base_ref }}
 
       - name: Find changes (push)
         if: github.event_name != 'pull_request'
@@ -44,7 +46,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: env.test_scope != ''
-        run: ct lint ${{ env.test_scope }} --validate-maintainers=false --check-version-increment=false
+        run: ct lint $test_scope --validate-maintainers=false --check-version-increment=false
 
       - name: Create kind cluster
         if: env.test_scope != ''
@@ -52,4 +54,4 @@ jobs:
 
       - name: Run chart-testing (install)
         if: env.test_scope != ''
-        run: ct install ${{ env.test_scope }}
+        run: ct install $test_scope

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -20,7 +20,7 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.x
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: zizmor
+
+on:
+  push:
+  pull_request:
+
+permissions: { }
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+    - name: Checkout project
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Check GitHub workflows with [zizmor](https://docs.zizmor.sh/integrations/#github-actions).
- Fix violations:
  - avoid template injection
  - limit workflow permissions
  - pin actions to SHA
- Add license header in two workflow files

https://issues.apache.org/jira/browse/HDDS-14920

## How was this patch tested?

tests: https://github.com/adoroszlai/ozone-helm-charts/actions/runs/24505815606
zizmor: https://github.com/adoroszlai/ozone-helm-charts/actions/runs/24505815574/job/71623942959#step:3:101

(`Find changes (PR)` will be tested by the PR itself.)