### PR TITLE
HDDS-14803. Update Helm Chart to use Ozone 2.1.1

### DIFF
--- a/charts/ozone/Chart.yaml
+++ b/charts/ozone/Chart.yaml
@@ -18,8 +18,8 @@ apiVersion: v2
 name: ozone
 description: The official Helm chart for Apache Ozone
 type: application
-version: 0.2.0
-appVersion: "2.0.0"
+version: 0.3.0
+appVersion: "2.1.1"
 home: https://ozone.apache.org
 icon: https://ozone.apache.org/ozone-logo.png
 sources:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump the Ozone Helm chart to use Apache Ozone 2.1.1:

* `appVersion`: `2.0.0` → `2.1.1`
* chart `version`: `0.2.0` → `0.3.0` (triggers chart release on merge)

**Note: This PR releases a new 0.3.0 version of the Helm chart when merged!**


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14803

## How was this patch tested?

* `helm lint charts/ozone`
* `helm template` — image resolves to `apache/ozone:2.1.1`
* `helm install` on kind; all pods Running with image `apache/ozone:2.1.1`