### PR TITLE
HDDS-15856. failed linting charts: must be in a git repository

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Run chart-testing (lint)
         if: env.test_scope != ''
         run: |
-          $DOCKER_COMMAND -v $(pwd):/data $CT_IMAGE \
+          $DOCKER_COMMAND -v $(pwd):/data --user $(id -u) $CT_IMAGE \
               ct lint $test_scope --validate-maintainers=false --check-version-increment=false
 
       - name: Set up Helm


### PR DESCRIPTION
## What changes were proposed in this pull request?

PR `test` run [failed](https://github.com/apache/ozone-helm-charts/actions/runs/29313244734/job/87046058019?pr=39#step:6:10):

```
Linting charts...
Error: failed linting charts: failed identifying charts to process: must be in a git repository
```

Steps to reproduce:

```bash
$ docker run -it --network host --rm -w /data -v $(pwd):/data quay.io/helmpack/chart-testing:v3.14.0 ct lint                                                                         
Linting charts...

------------------------------------------------------------------------------------------------------------------------
No chart changes detected.
------------------------------------------------------------------------------------------------------------------------
Error: failed linting charts: failed identifying charts to process: must be in a git repository
failed linting charts: failed identifying charts to process: must be in a git repository
```

https://issues.apache.org/jira/browse/HDDS-15856

## How was this patch tested?

Tested on this branch:

```bash
$ docker run -it --network host --rm -w /data -v $(pwd):/data --user $(id -u) quay.io/helmpack/chart-testing:v3.14.0 ct lint
Linting charts...

------------------------------------------------------------------------------------------------------------------------
No chart changes detected.
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```

Also tested on #39:

```bash
$ docker run -it --network host --rm -w /data -v $(pwd):/data --user $(id -u) quay.io/helmpack/chart-testing:v3.14.0 ct lint --target-branch 'main' --validate-maintainers=false --check-version-increment=false
Linting charts...

------------------------------------------------------------------------------------------------------------------------
 Charts to be processed:
------------------------------------------------------------------------------------------------------------------------
 ozone => (version: "0.3.0", path: "charts/ozone")
------------------------------------------------------------------------------------------------------------------------

Linting chart "ozone => (version: \"0.3.0\", path: \"charts/ozone\")"
Validating charts/ozone/Chart.yaml...
Validation success! 👍
==> Linting charts/ozone

1 chart(s) linted, 0 chart(s) failed

------------------------------------------------------------------------------------------------------------------------
 ✔︎ ozone => (version: "0.3.0", path: "charts/ozone")
------------------------------------------------------------------------------------------------------------------------
All charts linted successfully
```
