### PR TITLE
HDDS-15859. failed linting charts: targetBranch does not exist

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,9 +44,9 @@ jobs:
       - name: Find changes (PR)
         if: github.event_name == 'pull_request'
         run: |
-          changed=$($DOCKER_COMMAND -v $(pwd):/data --user $(id -u) $CT_IMAGE ct list-changed --target-branch "$base_ref")
+          changed=$($DOCKER_COMMAND -v $(pwd):/data --user $(id -u) $CT_IMAGE ct list-changed --target-branch $base_ref)
           if [[ -n "$changed" ]]; then
-            echo "test_scope=--target-branch '$base_ref'" >> "$GITHUB_ENV"
+            echo "test_scope=--target-branch $base_ref" >> "$GITHUB_ENV"
           fi
         env:
           base_ref: ${{ github.base_ref }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,5 +73,5 @@ jobs:
       - name: Run chart-testing (install)
         if: env.test_scope != ''
         run: |
-          $DOCKER_COMMAND -v $(pwd):/data -v ~/.kube/config:/root/.kube/config:ro $CT_IMAGE \
+          $DOCKER_COMMAND -v $(pwd):/data -v ~/.kube/config:/root/.kube/config:ro --user $(id -u) $CT_IMAGE \
               ct install $test_scope

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,4 +74,4 @@ jobs:
         if: env.test_scope != ''
         run: |
           $DOCKER_COMMAND -v $(pwd):/data -v ~/.kube/config:/root/.kube/config:ro $CT_IMAGE \
-              ct install
+              ct install --all

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -73,5 +73,5 @@ jobs:
       - name: Run chart-testing (install)
         if: env.test_scope != ''
         run: |
-          $DOCKER_COMMAND -v $(pwd):/data -v ~/.kube/config:/root/.kube/config:ro --user $(id -u) $CT_IMAGE \
+          $DOCKER_COMMAND -v $(pwd):/data -v ~/.kube/config:/root/.kube/config:ro $CT_IMAGE \
               ct install $test_scope

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,4 +74,4 @@ jobs:
         if: env.test_scope != ''
         run: |
           $DOCKER_COMMAND -v $(pwd):/data -v ~/.kube/config:/root/.kube/config:ro $CT_IMAGE \
-              ct install $test_scope
+              ct install


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix quoting [problem](https://github.com/apache/ozone-helm-charts/actions/runs/29344111249/job/87124324187?pr=39#step:6:16):

```
Linting charts...
Error: failed linting charts: failed identifying charts to process: targetBranch 'origin/'main'' does not exist
```

2. Fix `failed installing charts: ... must be in a git repository`.
   Passing `--user` as for other `docker run ... ct` command caused [failure](https://github.com/adoroszlai/ozone-helm-charts/actions/runs/29345685802/job/87128643141): `connection to the server localhost:8080 was refused`.

https://issues.apache.org/jira/browse/HDDS-15859

## How was this patch tested?

`push`: https://github.com/adoroszlai/ozone-helm-charts/actions/runs/29346441074/job/87131274777
`pull_request`: https://github.com/adoroszlai/ozone-helm-charts/actions/runs/29346661070/job/87132032924