### PR TITLE
HDDS-15874. Adding readinessProbe for helm HA deployments

### DIFF
--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -33,6 +33,7 @@ metadata:
     app.kubernetes.io/component: om
 spec:
   replicas: {{ .Values.om.replicas }}
+  podManagementPolicy: Parallel
   serviceName: {{ .Release.Name }}-om-headless
   selector:
     matchLabels:
@@ -118,6 +119,17 @@ spec:
                       ozone admin om transfer -id {{ .Values.clusterId }} -r || true
                       sleep 10
                     fi
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  ozone admin om roles -id {{ .Values.clusterId }} 2>/dev/null | grep $(hostname) | grep -qE 'LEADER|FOLLOWER' && exit 0 || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 3
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -126,10 +126,10 @@ spec:
                 - -c
                 - |
                   ozone admin om roles -id {{ .Values.clusterId }} 2>/dev/null | grep $(hostname) | grep -qE 'LEADER|FOLLOWER' && exit 0 || exit 1
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 20
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.om.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.om.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.om.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.om.readinessProbe.failureThreshold }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -144,10 +144,10 @@ spec:
                 - -c
                 - |
                   ozone admin scm roles 2>/dev/null | grep $(hostname -f) | grep -qE 'LEADER|FOLLOWER' && exit 0 || exit 1
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 20
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.scm.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.scm.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.scm.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.scm.readinessProbe.failureThreshold }}
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -137,6 +137,17 @@ spec:
                       ozone admin scm transfer -id {{ .Values.clusterId }} -r || true
                       sleep 10
                     fi
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  ozone admin scm roles 2>/dev/null | grep $(hostname -f) | grep -qE 'LEADER|FOLLOWER' && exit 0 || exit 1
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 20
+            failureThreshold: 3
           {{- end }}
           livenessProbe:
             httpGet:

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -146,6 +146,12 @@ om:
   tolerations: []
   # Ozone Manager security context (overwrites common security context)
   securityContext: {}
+  # Readiness probe for Ozone Manager HA (used when om.replicas > 1)
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 3
   # Ozone Manager service configuration
   service:
     type: ClusterIP
@@ -202,6 +208,12 @@ scm:
   tolerations: []
   # Storage Container Manager security context (overwrites common security context)
   securityContext: {}
+  # Readiness probe for Storage Container Manager HA (used when scm.replicas > 1)
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 20
+    failureThreshold: 3
   # Storage Container Manager service configuration
   service:
     type: ClusterIP


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change adds a `readinessProbe` for HA OM/SCM deployments so pods are removed from Service endpoints until they have a stable Ratis role (`LEADER` or `FOLLOWER`).

The chart already has (or will have via [[HDDS-14349](https://issues.apache.org/jira/browse/HDDS-14349)]) an HTTP `livenessProbe` and a roles-based `startupProbe`. **Startup** answers “still initializing do not treat liveness failures as fatal.” **Readiness** answers “should this pod receive client traffic via Service endpoints now?”

A roles exec `readinessProbe` matches the [[reviewer sample](https://github.com/apache/ozone-helm-charts/pull/20#discussion_r2631983830)] and is stricter than UI `httpGet`: a process can respond on the UI port before OM/SCM has joined the HA ring in a follower/leader role.

### In scope

* OM HA (`replicas > 1`): `readinessProbe` via `ozone admin om roles`, requiring `LEADER|FOLLOWER` on the line that matches `$(hostname)`
* SCM HA (`replicas > 1`): `readinessProbe` via `ozone admin scm roles`, with `$(hostname -f)` to match SCM roles output format
* Probe timings from kind testing: `timeoutSeconds: 20` (sample `5` is too low while peers/DNS/Ratis are still forming)
* **SCM HA headless DNS (if not already present):** `publishNotReadyAddresses: true` on `scm-service-headless` when `scm.replicas > 1` — same peer-DNS requirement as OM during bootstrap/readiness

### Probe shape (illustrative; OM)

```yaml
readinessProbe:
  exec:
    command:
      - sh
      - -c
      - |
        ozone admin om roles -id {{ .Values.clusterId }} 2>/dev/null \
          | grep $(hostname) | grep -qE 'LEADER|FOLLOWER' && exit 0 || exit 1
  initialDelaySeconds: 10
  periodSeconds: 10
  timeoutSeconds: 20
  failureThreshold: 3
```

SCM HA uses `ozone admin scm roles` with `$(hostname -f)` and the same `LEADER|FOLLOWER` grep.

Non-HA (`replicas == 1`) does not add roles exec readiness.

Startup ([[HDDS-14349](https://issues.apache.org/jira/browse/HDDS-14349)]) only checks membership in the roles list; readiness additionally requires `LEADER|FOLLOWER`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15874

## How was this patch tested?

### 1. kind — default install (OM HA)

On a fresh kind cluster:

```bash
helm upgrade --install ozone charts/ozone --wait --timeout 15m
```

Results:

* Release deployed; all pods Ready with no restarts
* During cold start, OM may show 1–2 Startup `timed out after 20s` events while peers/roles are not ready; within `failureThreshold` the probe succeeds and Ready is reached **without** repeated liveness Killing
* Green CI run and manually verified leader transfer and basic ozone commands

### 2. kind — SCM HA (`scm.replicas=3`, fresh install)

On a **new** release/cluster (do not scale an existing `scm.replicas=1` in place):

```bash
helm upgrade --install ozone charts/ozone \
  --set scm.replicas=3 \
  --wait --timeout 20m
```

Same pass criteria: Ready, no restart storm.

**Out of scope for this issue/PR:** `kubectl scale` or `helm upgrade --set scm.replicas=3` migrating an existing **scm 1→3** deployment (known STS revision / `addSCM` issues; track separately).