### PR TITLE
HDDS-15903. Fix imagePullSecrets support

### DIFF
--- a/charts/ozone/templates/datanode/datanode-statefulset.yaml
+++ b/charts/ozone/templates/datanode/datanode-statefulset.yaml
@@ -48,6 +48,9 @@ spec:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: datanode
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: datanode
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/ozone/templates/helm/om-decommission-job.yaml
+++ b/charts/ozone/templates/helm/om-decommission-job.yaml
@@ -28,6 +28,9 @@ spec:
         {{- include "ozone.selectorLabels" $ | nindent 8 }}
         app.kubernetes.io/component: helm-manager
     spec:
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: om-decommission
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"

--- a/charts/ozone/templates/helm/om-leader-transfer-job.yaml
+++ b/charts/ozone/templates/helm/om-leader-transfer-job.yaml
@@ -27,6 +27,9 @@ spec:
         {{- include "ozone.selectorLabels" $ | nindent 8 }}
         app.kubernetes.io/component: helm-manager
     spec:
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: om-leader-transfer
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag | default $.Chart.AppVersion }}"

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -49,6 +49,9 @@ spec:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: om
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and .Values.om.persistence.enabled (gt (len $bnodes) 0) }}
       initContainers:
         - name: om-bootstrap

--- a/charts/ozone/templates/recon/recon-deployment.yaml
+++ b/charts/ozone/templates/recon/recon-deployment.yaml
@@ -44,6 +44,9 @@ spec:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: recon
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:  {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: recon
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/ozone/templates/s3g/s3g-statefulset.yaml
+++ b/charts/ozone/templates/s3g/s3g-statefulset.yaml
@@ -48,6 +48,9 @@ spec:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: s3g
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: s3g
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -49,6 +49,9 @@ spec:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: scm
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: init
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
## What changes were proposed in this pull request?
The PR fixes `imagePullSecrets` support to all Ozone pod templates, enabling deployments to clusters that require private registry authentication.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15903

## How was this patch tested?

**Render changed templates (excluding om decommission jobs) with provided `imagePullSecrets` value:**
```shell
helm template ozone charts/ozone --set "imagePullSecrets[0].name=regcred" --set recon.enabled=true \
  -s templates/datanode/datanode-statefulset.yaml \
  -s templates/om/om-statefulset.yaml \
  -s templates/recon/recon-deployment.yaml \
  -s templates/s3g/s3g-statefulset.yaml \
  -s templates/scm/scm-statefulset.yaml
```
Output (reduced):
```shell
---
# Source: ozone/templates/datanode/datanode-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-datanode
spec:
  replicas: 3
  serviceName: ozone-datanode-headless
  template:
    spec:
      imagePullSecrets:
        - name: regcred
      containers:
        - name: datanode
          image: "apache/ozone:2.1.1"
          ...
---
# Source: ozone/templates/om/om-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-om
spec:
  replicas: 3
  serviceName: ozone-om-headless
  template:
    spec:
      imagePullSecrets:
        - name: regcred
      containers:
        - name: om
          image: "apache/ozone:2.1.1"
          ...
---
# Source: ozone/templates/recon/recon-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ozone-recon
spec:
  replicas: 1
  template:
    spec:
      imagePullSecrets:
        - name: regcred
      containers:
        - name: recon
          image: "apache/ozone:2.1.1"
          ...
---
# Source: ozone/templates/s3g/s3g-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-s3g
spec:
  replicas: 1
  serviceName: ozone-s3g-headless
  template:
    spec:
      imagePullSecrets:
        - name: regcred
      containers:
        - name: s3g
          image: "apache/ozone:2.1.1"
          ...
---
# Source: ozone/templates/scm/scm-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: ozone-scm
spec:
  replicas: 1
  podManagementPolicy: Parallel
  serviceName: ozone-scm-headless
  template:
    spec:
      imagePullSecrets:
        - name: regcred
      initContainers:
        - name: init
          image: "apache/ozone:2.1.1"
          ...
```