### PR TITLE
HDDS-13828. Verify number of replicas for om and scm

### DIFF
--- a/charts/ozone/templates/NOTES.txt
+++ b/charts/ozone/templates/NOTES.txt
@@ -55,3 +55,18 @@ Recon
  To access Recon from a browser, use the following command and visit localhost:{{ .Values.recon.service.port }}
  $ kubectl port-forward svc/{{ .Release.Name }}-recon {{ .Values.recon.service.port }}:{{ .Values.recon.service.port }}
 {{- end }}
+
+****************
+*   Replicas   *
+****************
+Ozone Manager (om.replicas): {{ .Values.om.replicas }}
+Storage Container Manager (scm.replicas): {{ .Values.scm.replicas }}
+
+{{- if eq (mod .Values.om.replicas 2) 0 }}
+WARNING: om.replicas={{ .Values.om.replicas }} is even. Odd replica counts (1, 3, 5, ...) are recommended for Raft quorum.
+Even counts may be used temporarily during OM migration (bootstrap/decommission), but are not recommended as a steady state.
+{{- end }}
+{{- if eq (mod .Values.scm.replicas 2) 0 }}
+WARNING: scm.replicas={{ .Values.scm.replicas }} is even. Odd replica counts (1, 3, 5, ...) are recommended for Raft quorum.
+Even counts may be used temporarily during SCM migration (bootstrap/decommission), but are not recommended as a steady state.
+{{- end }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Adds a Replicas section to `NOTES.txt` so `helm install` / `upgrade` prints the configured `om.replicas` and `scm.replicas`.
* Emits a WARNING when either count is even (Raft quorum is better with odd sizes), but does **not** fail the install.
* Even replica counts remain allowed for OM/SCM migration intermediate states (see Jira discussion and [RATIS-2296](https://issues.apache.org/jira/browse/RATIS-2296)). Odd counts such as 5 are valid and are not warned.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-13828

## How was this patch tested?

* Green CI run
* Manual verification:

```bash
# NOTES are not shown by default with helm template; use dry-run
helm install ozone charts/ozone --dry-run --debug 2>&1 | tee /tmp/notes-default.txt
grep -nE 'Replicas|om.replicas|scm.replicas|WARNING' /tmp/notes-default.txt

# Even counts should show WARNING
helm install ozone charts/ozone --dry-run --set om.replicas=2 --set scm.replicas=4 2>&1 \
  | grep -E 'WARNING|om.replicas|scm.replicas'

# Odd non-1/3 (e.g. 5) must not fail / must not warn as even
helm install ozone charts/ozone --dry-run --set om.replicas=5 --set scm.replicas=1 2>&1 \
  | grep -E 'WARNING|om\.replicas\)|fail|Replicas'