### PR TITLE
HDDS-15904. Add affinity and tolerations support to om-decommission and om-leader-transfer jobs

### DIFF
--- a/charts/ozone/templates/helm/om-decommission-job.yaml
+++ b/charts/ozone/templates/helm/om-decommission-job.yaml
@@ -82,6 +82,12 @@ spec:
       {{- with $nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $securityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/ozone/templates/helm/om-leader-transfer-job.yaml
+++ b/charts/ozone/templates/helm/om-leader-transfer-job.yaml
@@ -64,6 +64,12 @@ spec:
       {{- with $nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with $securityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

The PR adds `affinity` and `tolerations` to the pod specs of the jobs defined in `om-decommission-job.yaml` and `om-leader-transfer-job.yaml`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15904

## How was this patch tested?

Similar to [templates/datanode/datanode-statefulset.yaml#L92-L97](https://github.com/apache/ozone-helm-charts/blob/d68c1492651620b5beaa601351648d5229626ee0/charts/ozone/templates/datanode/datanode-statefulset.yaml#L92-L97) and other resource definitions.