### PR TITLE
HDDS-14351. Add preStop and graceful termination for OM and SCM

### DIFF
--- a/charts/ozone/templates/om/om-service-headless.yaml
+++ b/charts/ozone/templates/om/om-service-headless.yaml
@@ -25,6 +25,7 @@ metadata:
     app.kubernetes.io/component: om
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: ui
       port: {{ .Values.om.service.port }}

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -49,6 +49,9 @@ spec:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: om
     spec:
+      {{- if gt (int .Values.om.replicas) 1 }}
+      terminationGracePeriodSeconds: 150
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -101,6 +104,21 @@ spec:
               containerPort: {{ .Values.om.service.port }}
             - name: ratis
               containerPort: {{ .Values.om.service.ratisPort }}
+          {{- if gt (int .Values.om.replicas) 1 }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - |
+                    LEADER=$(ozone admin om roles -id {{ .Values.clusterId }} 2>/dev/null | grep LEADER | awk '{print $1}')
+                    if [ "$LEADER" = "$(hostname)" ]; then
+                      echo "This OM is leader, transferring leadership..."
+                      ozone admin om transfer -id {{ .Values.clusterId }} -r || true
+                      sleep 10
+                    fi
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /

--- a/charts/ozone/templates/scm/scm-service-headless.yaml
+++ b/charts/ozone/templates/scm/scm-service-headless.yaml
@@ -25,6 +25,7 @@ metadata:
     app.kubernetes.io/component: scm
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: ui
       port: {{ .Values.scm.service.port }}

--- a/charts/ozone/templates/scm/scm-statefulset.yaml
+++ b/charts/ozone/templates/scm/scm-statefulset.yaml
@@ -49,6 +49,9 @@ spec:
         {{- include "ozone.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: scm
     spec:
+      {{- if gt (int .Values.scm.replicas) 1 }}
+      terminationGracePeriodSeconds: 150
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -120,6 +123,21 @@ spec:
             - name: grpc
               containerPort: {{ .Values.scm.service.grpcPort }}
             {{- end }}
+          {{- if gt (int .Values.scm.replicas) 1 }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - sh
+                  - -c
+                  - |
+                    LEADER_HOST=$(ozone admin scm roles 2>/dev/null | grep LEADER | cut -d: -f1)
+                    if [ "$LEADER_HOST" = "$(hostname -f)" ]; then
+                      echo "This SCM is leader, transferring leadership..."
+                      ozone admin scm transfer -id {{ .Values.clusterId }} -r || true
+                      sleep 10
+                    fi
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up to [PR #20 discussion](https://github.com/apache/ozone-helm-charts/pull/20#discussion_r2632054499): add a preStop hook / longer graceful termination so OM/SCM do not stop while still holding Ratis leadership.

* Add `lifecycle.preStop` on OM/SCM StatefulSets (`replicas > 1`): if this pod is leader, run `ozone admin om|scm transfer -r` before shutdown.
* Add `terminationGracePeriodSeconds` for HA OM/SCM (default path used **150s**) so a slow transfer + short sleep still finishes before SIGKILL.
* The preStop script only does the leader transfer; it does **not** send `kill -TERM 1` as in the [PR #20 discussion](https://github.com/apache/ozone-helm-charts/pull/20#discussion_r2632054499) sample. kubelet sends SIGTERM to the container automatically once preStop returns, and the image's PID 1 (`dumb-init`) forwards it to the OM/SCM process, so an explicit `kill` would just duplicate that and adds a dependency on the entrypoint's PID 1.
* Complements the existing pre-upgrade `om-leader-transfer-job` (scale-down + persistence); this covers ordinary pod delete / roll / drain.
* Set `publishNotReadyAddresses: true` on the OM/SCM headless Services. During termination a terminating endpoint always has `ready: false`, so by default it is dropped from the headless Service DNS ([Kubernetes docs](https://kubernetes.io/docs/tutorials/services/pods-and-endpoint-termination-flow/)). The transferee then cannot resolve the outgoing leader's address to confirm the handoff, and `transfer -r` blocks until `TIMED_OUT(60s)`. Publishing not-ready addresses keeps the terminating pod resolvable so the transfer completes quickly (see [discussion](https://github.com/apache/ozone-helm-charts/pull/20#discussion_r3619734581)).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14351

## How was this patch tested?

- Green CI run, and tested manually with leader transfer and basic ozone commands.
* kind, OM HA (`om.replicas=3`): over repeated leader pod-delete cycles, preStop transfers leadership and quorum consistently recovers to a single LEADER.
* kind, SCM HA (`scm.replicas=3`): same repeated leader pod-delete cycles, with the same result.
* Compared with `main` (both OM and SCM): no preStop / default 30s grace; deleting the leader does **not** attempt transfer (failover is only Raft election after SIGTERM).

Manually Test:

```bash
kind create cluster --name ozone-helm-prestop

# OM HA (default)
helm upgrade --install ozone charts/ozone --wait --timeout 15m
kubectl exec ozone-om-0 -c om -- ozone admin om roles -id cluster1
kubectl delete pod ozone-om-1                       # delete current LEADER
kubectl get events --sort-by='.lastTimestamp' | grep -iE 'preStop|Killing'
kubectl exec ozone-om-0 -c om -- ozone admin om roles -id cluster1
# expect: single LEADER; transfer done in preStop (no TIMED_OUT)

# SCM HA
helm upgrade --install ozone charts/ozone --set scm.replicas=3 --wait --timeout 20m
kubectl exec ozone-scm-0 -c scm -- ozone admin scm roles -id cluster1
kubectl delete pod ozone-scm-1                       # delete current LEADER
kubectl get events --sort-by='.lastTimestamp' | grep -iE 'preStop|Killing'
kubectl exec ozone-scm-0 -c scm -- ozone admin scm roles -id cluster1
# expect: single LEADER; transfer done in preStop
```