### PR TITLE
HDDS-14350. Ratis configurations for ozone helm charts

### DIFF
--- a/charts/ozone/templates/_helpers.tpl
+++ b/charts/ozone/templates/_helpers.tpl
@@ -171,6 +171,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: OZONE-SITE.XML_ozone.recon.address
   value: "{{- printf "%s-recon.%s.svc.cluster.local" $.Release.Name $.Release.Namespace }}:9891"
 {{- end }}
+{{- range $k, $v := .Values.ratis.ozoneSite }}
+- name: OZONE-SITE.XML_{{ $k }}
+  value: {{ $v | quote }}
+{{- end }}
 {{- end }}
 
 {{/* Common configuration environment variables */}}

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -54,6 +54,25 @@ configuration:
   #        - key: ozone
   #          path: /etc/hadoop/ozone-site.xml
 
+# Advanced Ratis (OM/SCM) tuning: network resilience timeouts and leader election.
+ratis:
+  # Empty by default; Ozone's built-in defaults apply.
+  # A curated set of properties useful on slow/flaky networks. Values below are
+  # Ozone 2.1.1's own defaults; edit before uncommenting. See ozone-default.xml
+  # for the up-to-date list of available properties:
+  #   ozoneSite:
+  #     ozone.om.ratis.server.request.timeout: "3s"
+  #     ozone.om.ratis.minimum.timeout: "5s"
+  #     ozone.om.ratis.server.failure.timeout.duration: "120s"
+  #     ozone.om.ratis.server.leaderelection.pre-vote: "true"
+  #     ozone.scm.ha.ratis.request.timeout: "30s"
+  #     ozone.scm.ha.ratis.leader.election.timeout: "5s"
+  #     # unset (empty) by default; falls back to leader.election.timeout above
+  #     ozone.scm.ha.raft.server.rpc.first-election.timeout: "10s"
+  #     ozone.scm.ha.ratis.server.leaderelection.pre-vote: "true"
+  #     ozone.scm.ha.ratis.server.failure.timeout.duration: "120s"
+  ozoneSite: {}
+
 # Constrain all Ozone pods to nodes with specific node labels
 nodeSelector: {}
 # Constrain all Ozone pods to nodes by affinity/anti-affinity rules


### PR DESCRIPTION
## What changes were proposed in this pull request?

Analyse Ratis configurations for handling network partitions / slow networks, covering Ratis timeouts, heartbeat settings, and leader election. This follows up on the HA Helm work in comment [r2632023653](https://github.com/apache/ozone-helm-charts/pull/20#discussion_r2632023653).

* Adds `ratis.ozoneSite` to `values.yaml`: an empty map by default for optional `ozone-site` property overrides, with a curated, commented example list covering OM/SCM Ratis network-resilience timeouts and leader election.
* Renders `ratis.ozoneSite` entries as `OZONE-SITE.XML_*` env vars from `ozone.configuration.env.common` in `_helpers.tpl`, reusing the convention already used throughout the chart.

Curated keys documented as commented examples in `values.yaml` (any other `ozone-site`
property can also be set via this map):
* OM: `ozone.om.ratis.server.request.timeout`, `ozone.om.ratis.minimum.timeout`,
  `ozone.om.ratis.server.failure.timeout.duration`, `ozone.om.ratis.server.leaderelection.pre-vote`
* SCM: `ozone.scm.ha.ratis.request.timeout`, `ozone.scm.ha.ratis.leader.election.timeout`,
  `ozone.scm.ha.raft.server.rpc.first-election.timeout`,
  `ozone.scm.ha.ratis.server.leaderelection.pre-vote`,
  `ozone.scm.ha.ratis.server.failure.timeout.duration`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-14350

## How was this patch tested?

* Green CI run
* Manual verification:

```bash
# default: no ratis override env vars rendered
helm template test-release charts/ozone --show-only templates/om/om-statefulset.yaml | grep OZONE-SITE.XML_

# with overrides
cat > /tmp/ratis-override.yaml <<'EOF'
ratis:
  ozoneSite:
    ozone.om.ratis.server.request.timeout: "10s"
EOF
# expect:
#   - name: OZONE-SITE.XML_ozone.om.ratis.server.request.timeout
#     value: "10s"
helm template test-release charts/ozone -f /tmp/ratis-override.yaml \
  --show-only templates/om/om-statefulset.yaml \
  | grep -A1 'OZONE-SITE.XML_ozone.om.ratis.server.request.timeout'
  
# real cluster smoke test
kind create cluster --name ozone-helm-ratis
helm upgrade --install ozone charts/ozone --wait --timeout 15m
helm upgrade ozone charts/ozone -f /tmp/ratis-override.yaml --wait --timeout 15m
kubectl exec ozone-om-0 -- env | grep ratis.server.request.timeout
```