### PR TITLE
HDDS-15994. Update Helm Chart to use Ozone 2.2.0

### DIFF
--- a/charts/ozone/Chart.yaml
+++ b/charts/ozone/Chart.yaml
@@ -19,7 +19,7 @@ name: ozone
 description: The official Helm chart for Apache Ozone
 type: application
 version: 0.3.0
-appVersion: "2.1.1"
+appVersion: "2.2.0"
 home: https://ozone.apache.org
 icon: https://ozone.apache.org/ozone-logo.png
 sources:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump the Ozone Helm chart to use Apache Ozone 2.2.0:

* `appVersion`: `2.1.1` → `2.2.0`


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15994

## How was this patch tested?

* `helm template` image resolves to `apache/ozone:2.2.0`
* `helm install` on kind; all pods Running with image `apache/ozone:2.2.0`

