### PR TITLE
HDDS-15993. Unused values in ozone helm chart values.yaml

### DIFF
--- a/charts/ozone/templates/helm/om-decommission-job.yaml
+++ b/charts/ozone/templates/helm/om-decommission-job.yaml
@@ -27,6 +27,9 @@ spec:
       labels:
         {{- include "ozone.selectorLabels" $ | nindent 8 }}
         app.kubernetes.io/component: helm-manager
+      {{- with $.Values.helm.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
@@ -37,6 +40,9 @@ spec:
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           {{- with $.Values.om.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.helm.resources }}
+          resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - sh

--- a/charts/ozone/templates/helm/om-leader-transfer-job.yaml
+++ b/charts/ozone/templates/helm/om-leader-transfer-job.yaml
@@ -26,6 +26,9 @@ spec:
       labels:
         {{- include "ozone.selectorLabels" $ | nindent 8 }}
         app.kubernetes.io/component: helm-manager
+      {{- with $.Values.helm.podAnnotations }}
+      annotations: {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with $.Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
@@ -36,6 +39,9 @@ spec:
           imagePullPolicy: {{ $.Values.image.pullPolicy }}
           {{- with $.Values.om.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with $.Values.helm.resources }}
+          resources: {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
             - sh

--- a/charts/ozone/templates/om/om-bootstrap-configmap.yaml
+++ b/charts/ozone/templates/om/om-bootstrap-configmap.yaml
@@ -11,7 +11,8 @@ data:
     #!/bin/sh
     set -e
 
-    HELM_MANAGER_PATH="{{ .Values.om.persistence.path }}{{ .Values.helm.persistence.path }}"
+    # "/data" is a fixed marker-subdirectory name, not user-configurable.
+    HELM_MANAGER_PATH="{{ .Values.om.persistence.path }}/data"
     HELM_MANAGER_BOOTSTRAPPED_FILE="$HELM_MANAGER_PATH/bootstrapped"
 
     # These are templated from Helm

--- a/charts/ozone/values.yaml
+++ b/charts/ozone/values.yaml
@@ -286,11 +286,11 @@ helm:
   env: []
   # Additional Helm Manager envFrom items to set up environment variables (templated)
   envFrom: []
-  # Storage Container Manager resource requests and limits
+  # Helm Manager Job resource requests and limits
   resources: {}
-  # Extra annotations for Storage Container Manager pods
+  # Extra annotations for Helm Manager Job pods
   podAnnotations: {}
-  # Constrain Storage Container Manager pods to nodes with specific node labels
+  # Constrain Helm Manager pods to nodes with specific node labels
   nodeSelector: {}
   # Constrain Helm Manager pods to nodes by affinity/anti-affinity rules
   affinity: {}
@@ -303,20 +303,6 @@ helm:
   # This can happen if PVC has been deleted or is not reachable.
   # This is used for decommissioning OM
   backoffLimit: 5
-  # Helm Manager persistence (this is enabled automatically if al least one
-  # of datanode, scm or om is enabled)
-  persistence:
-    # Enable persistence
-    enabled: false
-    # Persistence access modes
-    accessModes:
-      - ReadWriteOnce
-    # Path for Storage Container Manager volume mount
-    path: /data
-    # Volume size
-    size: 10Gi
-    # The name of a specific storage class name to use
-    storageClassName: ~
 
 # Recon configuration
 recon:


### PR DESCRIPTION
## What changes were proposed in this pull request?

`charts/ozone/values.yaml` listed several `helm.*` keys that templates never consumed. Users could set them and reasonably expect an effect; nothing happened. This change aligns values with real behavior.

### Wire (keep + consume)

* `helm.resources` and `helm.podAnnotations` are now applied to both helm-manager Jobs:
  * `om-leader-transfer-job` (`pre-upgrade`)
  * `om-decommission-job` (`post-upgrade`)
* Use same pattern used by OM/SCM/DN/S3G StatefulSets.

### Remove (unused + misleading)

* Drop unused `helm.persistence` keys that never had template consumers: `enabled`, `accessModes`, `size`, `storageClassName`.
* Remove the comment claiming helm-manager persistence is enabled automatically when datanode/scm/om persistence is on (that logic does not exist).
* Fix SCM copy-paste comments on `helm.resources` / `helm.podAnnotations`.

### Keep

* `helm.persistence.path` — still used to build `HELM_MANAGER_PATH` for the OM bootstrap stamp.

## Why no dedicated helm-manager PVC?

Helm Manager is not a long-running workload. It is ephemeral Helm hook Jobs (`pre-upgrade` leader-transfer, `post-upgrade` decommission; deleted after `hook-succeeded` / `hook-failed`). They do not own durable storage:

* Decommission mounts the **existing OM PVC** to wipe content.
* The bootstrap stamp is written on the **OM volume**, not a helm-manager volume.

So `enabled` / `accessModes` / `size` / `storageClassName` had nothing to attach to and implied a PVC API the chart never implemented.

## Why keep `helm.persistence.path`?

`path` is not a PVC knob. It only names a **subdirectory under the OM volume** for chart-managed markers:

```text
HELM_MANAGER_PATH = om.persistence.path + helm.persistence.path
default: /data + /data → /data/data
stamp file: /data/data/bootstrapped
```

The OM bootstrap initContainer uses that path so the stamp stays next to OM data but outside the Ozone metadata tree. Deleting `path` would break (or force hard-coding of) that layout; keeping it is intentional and documented in the values comment.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-15993

## How was this patch tested?

* Grep: removed persistence keys absent; `resources` / `podAnnotations` referenced from both Job templates; `helm.persistence.path` still used by bootstrap ConfigMap
* kind smoke: persistence + scale-down still works
* Green CI