### PR TITLE
HDDS-16172. Fix OM scale-up by moving bootstrap into the om container

### DIFF
--- a/charts/ozone/templates/om/om-bootstrap-configmap.yaml
+++ b/charts/ozone/templates/om/om-bootstrap-configmap.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.om.persistence.enabled (gt (len (ternary (splitList "," (include "ozone.om.bootstrap.nodes" .)) (list) (ne "" (include "ozone.om.bootstrap.nodes" .)))) 0) }}
+{{- if and .Values.om.persistence.enabled (gt (len (ternary (splitList "," (include "ozone.om.bootstrap.nodes" .)) (list) (ne "" (include "ozone.om.bootstrap.nodes" .)))) 0) (not .Values.om.command) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,7 +22,7 @@ data:
 
     if [ -z "$OZONE_OM_BOOTSTRAP_NODES" ]; then
       echo "No bootstrap handling needed!"
-      exit 0
+      exec $OZONE_OM_ARGS_LIST
     fi
 
     joinArr() {
@@ -32,23 +32,41 @@ data:
 
     run_bootstrap() {
       local overwriteCmd="$1"
-      local max_attempts=3
+      local max_attempts=6
       local attempt=1
       local base_delay=5
       local exit_code=0
+      local child=""
+      local joined=false
       
       echo "Bootstrapping node config for this node: $overwriteCmd"
+
+      trap 'kill -TERM "$child" 2>/dev/null || true' TERM INT
       
       while [ $attempt -le $max_attempts ]; do
         echo "Bootstrap attempt $attempt of $max_attempts"
         
-        if ozone admin om --set "ozone.om.nodes.$OZONE_CLUSTER_ID=$overwriteCmd" --bootstrap; then
+        ozone om --set "ozone.om.nodes.$OZONE_CLUSTER_ID=$overwriteCmd" --bootstrap &
+        child=$!
+        joined=false
+
+        while kill -0 "$child" 2>/dev/null; do
+          if ozone admin om roles -id="$OZONE_CLUSTER_ID" 2>/dev/null | grep -q "^$HOSTNAME "; then
+            joined=true
+            break
+          fi
+          sleep 10
+        done
+
+        if [ "$joined" = true ]; then
           echo "$HOSTNAME was successfully bootstrapped!"
           mkdir -p "$HELM_MANAGER_PATH"
           touch "$HELM_MANAGER_BOOTSTRAPPED_FILE"
+          wait "$child" || exit $?
           exit 0
         else
-          exit_code=$?
+          exit_code=0
+          wait "$child" || exit_code=$?
           echo "Bootstrap failed with exit code $exit_code, attempt $attempt of $max_attempts"
           
           if [ $attempt -lt $max_attempts ]; then
@@ -93,6 +111,6 @@ data:
       run_bootstrap "$overwriteCmd"
     else
       echo "$HOSTNAME must not be started with bootstrap arg, or is already bootstrapped."
-      exit 0
+      exec $OZONE_OM_ARGS_LIST
     fi
 {{- end }}

--- a/charts/ozone/templates/om/om-statefulset.yaml
+++ b/charts/ozone/templates/om/om-statefulset.yaml
@@ -24,6 +24,8 @@
 {{- $tolerations := or .Values.om.tolerations .Values.tolerations }}
 {{- $securityContext := or .Values.om.securityContext .Values.securityContext }}
 {{- $bnodes := ternary (splitList "," (include "ozone.om.bootstrap.nodes" .)) (list) (ne "" (include "ozone.om.bootstrap.nodes" .)) }}
+{{/* The bootstrap wrapper replaces the container args, so it can only be used with the image entrypoint (i.e. no custom om.command) */}}
+{{- $bootstrapWrapper := and .Values.om.persistence.enabled (gt (len $bnodes) 0) (not .Values.om.command) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -55,28 +57,6 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.om.persistence.enabled (gt (len $bnodes) 0) }}
-      initContainers:
-        - name: om-bootstrap
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["/bin/sh", "/scripts/om-bootstrap.sh"]
-          env:
-            {{- include "ozone.configuration.env" . | nindent 12 }}
-            {{- with $env }}
-              {{- tpl (toYaml .) $ | nindent 12 }}
-            {{- end }}
-          {{- with $envFrom }}
-          envFrom: {{- tpl (toYaml .) $ | nindent 12 }}
-          {{- end }}
-          volumeMounts:
-            - name: config
-              mountPath: {{ .Values.configuration.dir }}
-            - name: {{ .Release.Name }}-om
-              mountPath: {{ .Values.om.persistence.path }}
-            - name: om-bootstrap-script
-              mountPath: /scripts
-      {{- end }}
       containers:
         - name: om
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -84,7 +64,11 @@ spec:
           {{- with .Values.om.command }}
           command: {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
+          {{- if $bootstrapWrapper }}
+          args: ["/bin/sh", "/scripts/om-bootstrap.sh"]
+          {{- else }}
           args: {{- tpl (toYaml .Values.om.args) $ | nindent 12 }}
+          {{- end }}
           env:
             {{- include "ozone.configuration.env" . | nindent 12 }}
             - name: WAITFOR
@@ -132,6 +116,10 @@ spec:
               mountPath: {{ .Values.configuration.dir }}
             - name: {{ .Release.Name }}-om
               mountPath: {{ .Values.om.persistence.path }}
+            {{- if $bootstrapWrapper }}
+            - name: om-bootstrap-script
+              mountPath: /scripts
+            {{- end }}
       {{- with $nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -145,7 +133,7 @@ spec:
       securityContext: {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
-        {{- if and .Values.om.persistence.enabled (gt (len $bnodes) 0) }}
+        {{- if $bootstrapWrapper }}
         - name: om-bootstrap-script
           configMap:
             name: {{ .Release.Name }}-om-bootstrap-script


### PR DESCRIPTION
## What changes were proposed in this pull request?

Scaling up OM replicas with `om.persistence.enabled=true` left the new OM pod stuck in `Init:0/1` CrashLoopBackOff, and `helm upgrade --wait` timed out.

The `om-bootstrap` init container invoked non-existent `ozone admin om --bootstrap`. Using the correct `ozone om --bootstrap` is not enough on its own: that command keeps running as the OM daemon, so it never completes inside an init container; `checkConfigBeforeBootstrap` also requires existing OMs to already know the new node, which only happens after a config-checksum rolling restart that StatefulSet OrderedReady blocks while the new pod stays in Init.

This patch removes the init container and runs bootstrap from the om container startup path instead:

* Wrapper as container `args` (image entrypoint kept for `envtoconf` / `ENSURE_OM_INITIALIZED`)
* Backgrounds `ozone om --set ozone.om.nodes.<id>=… --bootstrap`, polls `ozone admin om roles`, then writes the `bootstrapped` marker and `wait`s on the daemon
* Retries in-script so the pod stays Ready and the rolling update of peers can proceed
* ConfigMap render condition aligned with the wrapper gate (`not om.command`)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-16172

## How was this patch tested?

* `helm template`: fresh install keeps `args: [ozone, om]` and does not render the bootstrap ConfigMap
* kind: `om.replicas` 3→2→3 with persistence enabled for om/scm/datanode; new OM joins the ring (`ozone admin om roles`); PVC UID unchanged; `/data/data/bootstrapped` present
* Delete the scaled-up OM pod: restart takes the marker path (`already bootstrapped`) with no second bootstrap attempt